### PR TITLE
Fix to panic in support ticket 1932 due to invalid conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ The file is JSON object which is essentially a list of objects:
 [{
 	"ActionType": "GenerateOrLoginUserProfile",
 	"ID": "1",
-	"IdentityHandlerConfig": {},
+	"IdentityHandlerConfig": {
+	    "DashboardCredential": "ADVANCED-API-USER-API-TOKEN",
+	},
 	"OrgID": "53ac07777cbb8c2d53000002",
 	"ProviderConfig": {
 		"CallbackBaseURL": "http://tib.domain.com:3010",

--- a/main.go
+++ b/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"net/http"
 	"path"
 	"strconv"
-	"crypto/tls"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/TykTechnologies/tyk-identity-broker/backends"

--- a/providers/active_directory.go
+++ b/providers/active_directory.go
@@ -100,7 +100,7 @@ func (s *ADProvider) Init(handler tap.IdentityHandler, profile tap.Profile, conf
 }
 
 func (s *ADProvider) provideErrorRedirect(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, s.config.FailureRedirect, 301)
+	http.Redirect(w, r, s.config.FailureRedirect, http.StatusMovedPermanently) //301
 	return
 }
 

--- a/providers/social.go
+++ b/providers/social.go
@@ -164,11 +164,11 @@ func (s *Social) HandleCallback(w http.ResponseWriter, r *http.Request, onError 
 	constraintErr := s.checkConstraints(user)
 	if constraintErr != nil {
 		if s.config.FailureRedirect == "" {
-			onError(SocialLogTag, "Constraint failed", constraintErr, 400, w, r)
+			onError(SocialLogTag, "Constraint failed", constraintErr, http.StatusBadRequest, w, r) //400
 			return
 		}
 
-		http.Redirect(w, r, s.config.FailureRedirect, 301)
+		http.Redirect(w, r, s.config.FailureRedirect, http.StatusMovedPermanently) //301
 		return
 	}
 

--- a/tyk-api/tyk_api.go
+++ b/tyk-api/tyk_api.go
@@ -151,9 +151,8 @@ func (t *TykAPI) DispatchDashboard(target Endpoint, method string, usercode stri
 		return []byte{}, bErr
 	}
 
-	log.Debug("GOT:", string(retBody))
-
 	if response.StatusCode > 201 {
+		log.Warningf("Sent to endpoint %s", target)
 		log.Warning("Response code was: ", response.StatusCode)
 		log.Warning("GOT:", string(retBody))
 		return retBody, errors.New("Response code was not 200!")
@@ -199,7 +198,7 @@ func (t *TykAPI) DispatchDashboardSuper(target Endpoint, method string, body io.
 	}
 
 	if response.StatusCode > 201 {
-		log.Warning("Response code was: ", response.StatusCode)
+		log.Warning("DispatchDashboardSuper: Response code was: ", response.StatusCode)
 		log.Warning("Returned: ", string(retBody))
 		return retBody, errors.New("Response code was not 200!")
 	}


### PR DESCRIPTION
THe panic:

> dentity-provider_1  | 2018/03/21 14:39:42 http: panic serving 172.18.0.2:46896: interface conversion: interface {} is nil, not bool

- I have added a check to almost every field . Added to functions to make the Init function a bit more bearable (getOauthSettings, getTokenAuthSettings
- Added debug level otherwise we won't get the printouts and it's fixed on debug on main any way.
- A few debug messages and http codes
