### PR TITLE
Dockerfile for the public image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/*
+!tib_sample.conf
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:jessie-slim
+
+ARG TYKVERSION
+LABEL Description="Tyk Identity Broker docker image" Vendor="Tyk" Version=$TYKVERSION
+
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y --no-install-recommends \
+            curl ca-certificates apt-transport-https debian-archive-keyring \
+ && curl -L https://packagecloud.io/tyk/tyk-identity-broker/gpgkey | apt-key add - \
+ && apt-get autoremove -y \
+ && rm -rf /root/.cache
+
+RUN echo "deb https://packagecloud.io/tyk/tyk-identity-broker/debian/ jessie main" | tee /etc/apt/sources.list.d/tyk_tyk-identity-broker.list \
+ && apt-get update \
+ && apt-get install -y tyk-identity-broker=$TYKVERSION \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY ./tib_sample.conf /opt/tyk-identity-broker/tib.conf
+
+WORKDIR /opt/tyk-identity-broker
+
+CMD ["/opt/tyk-identity-broker/tyk-identity-broker", "-c", "/opt/tyk-identity-broker/tib.conf"]

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+TYKVERSION=$(cat version.go | gawk 'match($0, /v([0-9]+\.[0-9]+\.[0-9]+)/, ary) {print ary[1];}')
+
+echo "Executing custom build hook for version $TYKVERSION"
+docker build --build-arg TYKVERSION=$TYKVERSION -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
This includes a build hook for the Docker Hub so that it would automatically infer the package version from the version.go file and pass it as an argument to docker build.

Solves #23.