### PR TITLE
Add Health Check

### DIFF
--- a/http_handlers.go
+++ b/http_handlers.go
@@ -143,3 +143,7 @@ func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	thisIdentityProvider.HandleCallback(w, r, HandleError)
 	return
 }
+
+func HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/main.go
+++ b/main.go
@@ -91,6 +91,8 @@ func main() {
 
 	p.Handle("/api/profiles", IsAuthenticated(http.HandlerFunc(HandleGetProfileList))).Methods("GET")
 
+	p.Handle("/health", http.HandlerFunc(HandleHealthCheck)).Methods("GET")
+
 	listenPort := "3010"
 	if config.Port != 0 {
 		listenPort = strconv.Itoa(config.Port)


### PR DESCRIPTION
Health checks are required in order to use gcloud load balancing and/or ingresses for GKE. This pr adds a health check endpoint at `/health` that simply returns a 200 ok code