### PR TITLE
Add support for unstable Docker image builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,18 @@
 FROM debian:jessie-slim
 
 ARG TYKVERSION
+ARG REPOSITORY
 LABEL Description="Tyk Identity Broker docker image" Vendor="Tyk" Version=$TYKVERSION
 
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
             curl ca-certificates apt-transport-https debian-archive-keyring \
- && curl -L https://packagecloud.io/tyk/tyk-identity-broker/gpgkey | apt-key add - \
+ && curl -L https://packagecloud.io/tyk/$REPOSITORY/gpgkey | apt-key add - \
  && apt-get autoremove -y \
  && rm -rf /root/.cache
 
-RUN echo "deb https://packagecloud.io/tyk/tyk-identity-broker/debian/ jessie main" | tee /etc/apt/sources.list.d/tyk_tyk-identity-broker.list \
+RUN echo "deb https://packagecloud.io/tyk/$REPOSITORY/debian/ jessie main" | tee /etc/apt/sources.list.d/tyk_tyk-identity-broker.list \
  && apt-get update \
  && apt-get install -y tyk-identity-broker=$TYKVERSION \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -3,6 +3,11 @@ set -e
 
 echo "$PWD"
 
+echo "CACHE_TAG: $CACHE_TAG"
+echo "IMAGE_NAME: $IMAGE_NAME"
+echo "DOCKER_REPO: $DOCKER_REPO"
+echo "DOCKER_TAG: $DOCKER_TAG"
+
 dockerfilepath="$PWD/Dockerfile"
 repopath="$(dirname $PWD)"
 versionfile="$(cat $repopath/version.go)"
@@ -15,7 +20,8 @@ else
 fi
 
 REPOSITORY="tyk-identity-broker"
-if [[ $CACHE_TAG == "unstable" ]]; then
+imagetag=${IMAGE_NAME##*:}
+if [[ $imagetag == "unstable" ]]; then
     REPOSITORY="$REPOSITORY-unstable"
     TYKVERSION="*"  # Pick latest version from unstable repo
 fi

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -14,6 +14,13 @@ else
     exit 1
 fi
 
-echo "Executing custom build hook for version $TYKVERSION"
-docker build --build-arg TYKVERSION=$TYKVERSION -f $dockerfilepath -t $IMAGE_NAME $repopath
+REPOSITORY="tyk-identity-broker"
+if [[ $CACHE_TAG == "unstable" ]]; then
+    REPOSITORY="$REPOSITORY-unstable"
+    TYKVERSION="*"  # Pick latest version from unstable repo
+fi
+
+
+echo "Executing custom build hook for version $TYKVERSION from $REPOSITORY packagecloud repo"
+docker build --build-arg TYKVERSION=$TYKVERSION --build-arg REPOSITORY=$REPOSITORY -f $dockerfilepath -t $IMAGE_NAME $repopath
 


### PR DESCRIPTION
The build process looks like this:
Buddy pipeline creates the unstable packages on push to master ->
Triggers an `unstable` tag build on docker hub via a webhook ->
The build hook on docker hub determines if it's an `unstable` tag and then switches to the corresponding package repository, taking the latest version too, passing all that as args to `docker build`