### PR TITLE
Add flow to allow initial bind by admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,8 +573,6 @@ The LDAP Identity Provider is experimental currently and provides limited functi
 }
 ```
 
-**Step 1: Send a request to the LDAP URL**
-
 TIB can pull a username and password out of a request in two ways:
 
 1. Two form fields called "username" and "password"
@@ -582,7 +580,7 @@ TIB can pull a username and password out of a request in two ways:
 
 By default, TIB will look for the two form fields. To enable Basic Auth header extraction, add `"GetAuthFromBAHeader": true` to the `ProviderConfig` section.
 
-The request should be a `POST`.
+The request should be a `POST`. Example curl command can look like: `curl -X POST localhost:3010/auth/4/callback -F username=bob -F password=secret`
 
 If you make this request with a valid user that can bind to the LDAP server, Tyk will redirect the user to the dashboard with a valid session. There's no more to it, this mechanism is pass-through and is transparent to the user, with TIB acting as a direct client to the LDAP provider.
 
@@ -651,6 +649,29 @@ The configuration below will take a request that is posted to TIB, authenticate 
 	"ProviderName": "ADProvider",
 	"ReturnURL": "",
 	"Type": "passthrough"
+}
+```
+
+#### Using two phase LDAP authentification
+
+In some cases only priviliged users are allowed perform LDAP search. In this case you can specify your admin user using `LDAPAdminUser` and `LDAPAdminPassword` options. TIB will perform initial bind as admin user, then will do ldap lookup based on specified DN template or `LDAPFilter`, and will do bind one more time, with user DN.
+
+```
+{
+    "ActionType": "GenerateOrLoginUserProfile",
+    "ID": "4",
+    "OrgID": "59fc80d9158519599ca23cfc",
+    "ProviderConfig": {
+        "FailureRedirect": "https://tyk-dashboard:3000/?fail=true",
+        "LDAPPort": "389",
+        "LDAPAdminUser": "admin",
+        "LDAPAdminPassword": "password",
+        "LDAPServer": "localhost",
+        "LDAPUserDN": "uid=*USERNAME*,dc=example,dc=org"
+    },
+    "ProviderName": "ADProvider",
+    "ReturnURL": "https://tyk-dashboard:3000/tap",
+    "Type": "passthrough"
 }
 ```
 

--- a/providers/active_directory.go
+++ b/providers/active_directory.go
@@ -143,23 +143,11 @@ func (s *ADProvider) getUserData(username string, password string) (goth.User, e
 		UserID:   uname,
 		Provider: "ADProvider",
 	}
-/*
-	if s.config.LDAPFilter == "" {
-		log.Info(ADProviderLogTag + " LDAPFilter is blank, skipping")
 
-		var attrs []string
-		attrs = s.config.LDAPAttributes
-		attrs = append(attrs, s.config.LDAPEmailAttribute)
-
-		thisUser.Email = tap.GenerateSSOKey(thisUser)
-		log.Info(ADProviderLogTag+" User Data:", thisUser)
-
-		return thisUser, nil
-	}
-*/
     if s.config.LDAPFilter == "" {
         s.config.LDAPFilter = "(objectclass=*)"
     }
+
 	DN := s.config.LDAPBaseDN
 	if DN == "" {
 		DN = s.prepDN(username)
@@ -261,7 +249,11 @@ func (s *ADProvider) Handle(w http.ResponseWriter, r *http.Request) {
     }
 
 	if bindErr != nil {
-		log.Error(ADProviderLogTag+" Bind failed for user: ", username)
+        if s.config.LDAPAdminUser != "" {
+		    log.Error(ADProviderLogTag+" Bind failed for user: ", s.config.LDAPAdminUser)
+        } else {
+		    log.Error(ADProviderLogTag+" Bind failed for user: ", username)
+        }
 		log.Error(ADProviderLogTag+" --> Error was: ", bindErr)
 		s.provideErrorRedirect(w, r)
 		return

--- a/providers/active_directory.go
+++ b/providers/active_directory.go
@@ -37,6 +37,8 @@ type ADConfig struct {
 	LDAPBaseDN          string
 	LDAPFilter          string
 	LDAPEmailAttribute  string
+    LDAPAdminUser       string
+    LDAPAdminPassword   string
 	LDAPAttributes      []string
 	LDAPSearchScope     int
 	FailureRedirect     string
@@ -130,7 +132,7 @@ func (s *ADProvider) generateUsername(username string) string {
 	return uname
 }
 
-func (s *ADProvider) getUserData(username string) (goth.User, error) {
+func (s *ADProvider) getUserData(username string, password string) (goth.User, error) {
 	log.Info(ADProviderLogTag + " Search: starting...")
 	uname := username
 	if s.config.SlugifyUserName {
@@ -141,7 +143,7 @@ func (s *ADProvider) getUserData(username string) (goth.User, error) {
 		UserID:   uname,
 		Provider: "ADProvider",
 	}
-
+/*
 	if s.config.LDAPFilter == "" {
 		log.Info(ADProviderLogTag + " LDAPFilter is blank, skipping")
 
@@ -154,7 +156,10 @@ func (s *ADProvider) getUserData(username string) (goth.User, error) {
 
 		return thisUser, nil
 	}
-
+*/
+    if s.config.LDAPFilter == "" {
+        s.config.LDAPFilter = "(objectclass=*)"
+    }
 	DN := s.config.LDAPBaseDN
 	if DN == "" {
 		DN = s.prepDN(username)
@@ -188,20 +193,30 @@ func (s *ADProvider) getUserData(username string) (goth.User, error) {
 		return thisUser, errors.New("Filter matched multiple users")
 	}
 
+    entry := sr.Entries[0]
+
+    if s.config.LDAPEmailAttribute == "" {
+        s.config.LDAPEmailAttribute = "mail"
+    }
+
+    if s.config.LDAPAdminUser != "" {
+        bindErr := s.connection.Bind(entry.DN, password)
+        if bindErr != nil {
+            log.Error(ADProviderLogTag+" Bind failed for user: ", username)
+            log.Error(ADProviderLogTag+" --> Error was: ", bindErr)
+            return thisUser, errors.New("Password not matched")
+        }
+        log.Info(ADProviderLogTag+" User bind successful: ", username)
+    }
+
 	emailFound := false
-	for _, entry := range sr.Entries {
-		for _, j := range entry.Attributes {
-			log.Info("Checking ", j.Name, "with ", s.config.LDAPEmailAttribute)
-			if j.Name == s.config.LDAPEmailAttribute {
-				thisUser.Email = j.Values[0]
-				emailFound = true
-				break
-			}
-		}
-		if emailFound {
-			break
-		}
-	}
+    for _, j := range entry.Attributes {
+        if j.Name == s.config.LDAPEmailAttribute {
+            thisUser.Email = j.Values[0]
+            emailFound = true
+            break
+        }
+    }
 
 	if !emailFound {
 		log.Warning("User email not found, generating from username")
@@ -237,7 +252,13 @@ func (s *ADProvider) Handle(w http.ResponseWriter, r *http.Request) {
 
 	log.Debug("DN: ", s.prepDN(username))
 
-	bindErr := s.connection.Bind(s.prepDN(username), password)
+    var bindErr error
+
+    if s.config.LDAPAdminUser != "" {
+	    bindErr = s.connection.Bind(s.config.LDAPAdminUser, s.config.LDAPAdminPassword)
+    } else {
+	    bindErr = s.connection.Bind(s.prepDN(username), password)
+    }
 
 	if bindErr != nil {
 		log.Error(ADProviderLogTag+" Bind failed for user: ", username)
@@ -245,9 +266,12 @@ func (s *ADProvider) Handle(w http.ResponseWriter, r *http.Request) {
 		s.provideErrorRedirect(w, r)
 		return
 	}
-	log.Info(ADProviderLogTag+" User bind successful: ", username)
 
-	user, uErr := s.getUserData(username)
+    if s.config.LDAPAdminUser != "" {
+        log.Info(ADProviderLogTag+" User bind successful: ", username)
+    }
+
+	user, uErr := s.getUserData(username, password)
 	if uErr != nil {
 		log.Error(ADProviderLogTag+" Lookup failed for user: ", username)
 		log.Error(ADProviderLogTag+" --> Error was: ", uErr)


### PR DESCRIPTION
Now you can do a bind with admin user who are allowed to do a search,
and later it will bind one more time but with user DN.

Example profile:

```
{
    "ActionType": "GenerateOrLoginUserProfile",
    "ID": "4",
    "OrgID": "59fc80d9158519599ca23cfc",
    "ProviderConfig": {
        "FailureRedirect": "https://tyk-dashboard:3000/?fail=true",
        "LDAPAttributes": [],
        "LDAPPort": "389",
        "LDAPAdminUser": "admin",
        "LDAPAdminPassword": "password",
        "LDAPServer": "localhost",
        "LDAPUserDN": "uid=*USERNAME*,dc=example,dc=org"
    },
    "ProviderName": "ADProvider",
    "ReturnURL": "https://tyk-dashboard:3000/tap",
    "Type": "passthrough"
}
```

Additionally made a fix to always retrieve LDAP user email, since email
can be retrieed only when search is made. Fix is
basically setting "LDAPFilter" to `"(objectclass=*")` if its empty (same as
ldapsearch does by default if filter not passed), and doing a search
based on user DN.

Also `LDAPUserEmail` is `mail` by default