### PR TITLE
Deprecate SESSION_SECRET, add TYK_IB_SESSION_SECRET

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/TykTechnologies/tyk-identity-broker/tothic"
 	"io/ioutil"
 
 	"github.com/TykTechnologies/tyk-identity-broker/tyk-api"
 	"github.com/kelseyhightower/envconfig"
 )
-
-const envPrefix = "TYK_IB"
 
 var failCount int
 
@@ -57,7 +56,7 @@ func loadConfig(filePath string, conf *Configuration) {
 		}
 	}
 
-	if err = envconfig.Process(envPrefix, conf); err != nil {
+	if err = envconfig.Process(tothic.EnvPrefix, conf); err != nil {
 		log.Errorf("Failed to process config env vars: %v", err)
 	}
 

--- a/tothic/tothic_test.go
+++ b/tothic/tothic_test.go
@@ -1,0 +1,35 @@
+package tothic
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestKeyFromEnv(t *testing.T) {
+	expected := "SECRET"
+
+	t.Run("with new variable", func(t *testing.T) {
+		_ = os.Setenv("TYK_IB_SESSION_SECRET", expected)
+		_ = os.Setenv("SESSION_SECRET", "")
+		assert(t, expected, KeyFromEnv())
+	})
+
+	t.Run("with deprecated", func(t *testing.T) {
+		_ = os.Setenv("TYK_IB_SESSION_SECRET", "")
+		_ = os.Setenv("SESSION_SECRET", expected)
+		assert(t, expected, KeyFromEnv())
+	})
+
+	t.Run("with both", func(t *testing.T) {
+		_ = os.Setenv("SESSION_SECRET", "SOME_OTHER_SECRET")
+		_ = os.Setenv("TYK_IB_SESSION_SECRET", expected)
+		assert(t, expected, KeyFromEnv())
+	})
+}
+
+func assert(t *testing.T, expected interface{}, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}


### PR DESCRIPTION
This PR deprecates `SESSION_SECRET`. Also, it doesn't break backward compatibility.  It still supports  `SESSION_SECRET`. `TYK_IB_SESSION_SECRET` overrides if both set. 
Fixes #48 