### PR TITLE
Add support of salesforce provider

### DIFF
--- a/providers/social.go
+++ b/providers/social.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/oauth2"
 	"net/http"
 	"strings"
-	"golang.org/x/oauth2"
-	
+
 	"github.com/Sirupsen/logrus"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/bitbucket"
@@ -19,6 +19,7 @@ import (
 	"github.com/markbates/goth/providers/gplus"
 	"github.com/markbates/goth/providers/linkedin"
 	"github.com/markbates/goth/providers/openidConnect"
+	"github.com/markbates/goth/providers/salesforce"
 	"github.com/markbates/goth/providers/twitter"
 
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
@@ -109,6 +110,9 @@ func (s *Social) Init(handler tap.IdentityHandler, profile tap.Profile, config [
 
 		case "bitbucket":
 			gothProviders = append(gothProviders, bitbucket.New(provider.Key, provider.Secret, s.getCallBackURL(provider.Name)))
+
+		case "salesforce":
+			gothProviders = append(gothProviders, salesforce.New(provider.Key, provider.Secret, s.getCallBackURL(provider.Name)))
 
 		case "openid-connect":
 

--- a/vendor/github.com/markbates/goth/providers/salesforce/salesforce.go
+++ b/vendor/github.com/markbates/goth/providers/salesforce/salesforce.go
@@ -1,0 +1,163 @@
+// Package salesforce implements the OAuth2 protocol for authenticating users through salesforce.
+// This package can be used as a reference implementation of an OAuth2 provider for Goth.
+package salesforce
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+
+	"fmt"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+)
+
+const (
+	authURL  string = "https://login.salesforce.com/services/oauth2/authorize"
+	tokenURL string = "https://login.salesforce.com/services/oauth2/token"
+
+	//endpointProfile    string = "https://api.salesforce.com/2.0/users/me"
+)
+
+// Provider is the implementation of `goth.Provider` for accessing Salesforce.
+type Provider struct {
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
+}
+
+// New creates a new Salesforce provider and sets up important connection details.
+// You should always call `salesforce.New` to get a new provider.  Never try to
+// create one manually.
+func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	p := &Provider{
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		providerName: "salesforce",
+	}
+	p.config = newConfig(p, scopes)
+	return p
+}
+
+// Name is the name used to retrieve this provider later.
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
+}
+
+func (p *Provider) Client() *http.Client {
+	return goth.HTTPClientWithFallBack(p.HTTPClient)
+}
+
+// Debug is a no-op for the salesforce package.
+func (p *Provider) Debug(debug bool) {}
+
+// BeginAuth asks Salesforce for an authentication end-point.
+func (p *Provider) BeginAuth(state string) (goth.Session, error) {
+	return &Session{
+		AuthURL: p.config.AuthCodeURL(state),
+	}, nil
+}
+
+// FetchUser will go to Salesforce and access basic information about the user.
+func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	s := session.(*Session)
+	user := goth.User{
+		AccessToken:  s.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: s.RefreshToken,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
+	url, err := url.Parse(s.ID)
+	//creating dynamic url to retrieve user information
+	userURL := url.Scheme + "://" + url.Host + "/" + url.Path
+	req, err := http.NewRequest("GET", userURL, nil)
+	if err != nil {
+		return user, err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
+	resp, err := p.Client().Do(req)
+	if err != nil {
+		return user, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
+	err = userFromReader(resp.Body, &user)
+	return user, err
+}
+
+func newConfig(provider *Provider, scopes []string) *oauth2.Config {
+	c := &oauth2.Config{
+		ClientID:     provider.ClientKey,
+		ClientSecret: provider.Secret,
+		RedirectURL:  provider.CallbackURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
+		},
+		Scopes: []string{},
+	}
+
+	if len(scopes) > 0 {
+		for _, scope := range scopes {
+			c.Scopes = append(c.Scopes, scope)
+		}
+	}
+
+	return c
+}
+
+func userFromReader(r io.Reader, user *goth.User) error {
+	u := struct {
+		Name      string `json:"display_name"`
+		NickName  string `json:"nick_name"`
+		Location  string `json:"addr_country"`
+		Email     string `json:"email"`
+		AvatarURL string `json:"photos.picture"`
+		ID        string `json:"user_id"`
+	}{}
+	err := json.NewDecoder(r).Decode(&u)
+	if err != nil {
+		return err
+	}
+	user.Email = u.Email
+	user.Name = u.Name
+	user.NickName = u.Name
+	user.UserID = u.ID
+	user.Location = u.Location
+	return nil
+}
+
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
+	return true
+}
+
+//RefreshToken get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken: refreshToken}
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client()), token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
+}

--- a/vendor/github.com/markbates/goth/providers/salesforce/session.go
+++ b/vendor/github.com/markbates/goth/providers/salesforce/session.go
@@ -1,0 +1,72 @@
+package salesforce
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/markbates/goth"
+)
+
+// Session stores data during the auth process with Salesforce.
+// Expiry of access token is not provided by Salesforce, it is just controlled by timeout configured in auth2 settings
+// by individual users
+// Only way to check whether access token has expired or not is based on the response you receive if you try using
+// access token and get some error
+// Also, For salesforce refresh token to work follow these else remove scopes from here
+//On salesforce.com, navigate to where you app is configured. (Setup > Create > Apps)
+//Under Connected Apps, click on your application's name to view its settings, then click Edit.
+//Under Selected OAuth Scopes, ensure that "Perform requests on your behalf at any time" is selected. You must include this even if you already chose "Full access".
+//Save, then try your OAuth flow again. It make take a short while for the update to propagate.
+type Session struct {
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ID           string //Required to get the user info from sales force
+}
+
+var _ goth.Session = &Session{}
+
+// GetAuthURL will return the URL set by calling the `BeginAuth` function on the Salesforce provider.
+func (s Session) GetAuthURL() (string, error) {
+	if s.AuthURL == "" {
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
+	}
+	return s.AuthURL, nil
+}
+
+// Authorize the session with Salesforce and return the access token to be stored for future use.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	p := provider.(*Provider)
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client()), params.Get("code"))
+
+	if err != nil {
+		return "", err
+	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
+	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ID = token.Extra("id").(string) //Required to get the user info from sales force
+	return token.AccessToken, err
+}
+
+// Marshal the session into a string
+func (s Session) Marshal() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (s Session) String() string {
+	return s.Marshal()
+}
+
+// UnmarshalSession wil unmarshal a JSON string into a session.
+func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
+	s := &Session{}
+	err := json.NewDecoder(strings.NewReader(data)).Decode(s)
+	return s, err
+}


### PR DESCRIPTION
Fixes #60 

A new provider type `salesforce` is added to in Social Provider for Salesforce IDp.
Example Config
```json
{
 "ActionType": "GenerateOrLoginDeveloperProfile",
 "ID": "4",
 "IdentityHandlerConfig": {
  "DashboardCredential": ""
 },
 "OrgID": "5cd00524d85f245425510a78",
 "ProviderConfig": {
  "CallbackBaseURL": "http://localhost:3010",
  "FailureRedirect": "https://www.tyk-dashboard.com:3000/?fail=true",
  "UseProviders": [{
   "Name": "salesforce",
   "Key": "xxxx",
   "Secret": "xxxxx",
   "DiscoverURL": ""
  }]
 },
 "ProviderConstraints": {
  "Domain": "",
  "Group": ""
 },
 "ProviderName": "SocialProvider",
 "ReturnURL": "http://portal:3000/portal/sso/",
 "Type": "redirect"
}
```