### PR TITLE
Signing rpms using gpg2 and the agent

### DIFF
--- a/utils/dist_build.sh
+++ b/utils/dist_build.sh
@@ -11,7 +11,7 @@ echo "Set version number"
 
 if [ $BUILDPKGS == "1" ]; then
     echo "Importing signing key"
-    gpg --list-keys | grep -w $SIGNKEY && echo "Key exists" || gpg --import $BUILDTOOLSDIR/build_key.key
+    gpg --list-keys | grep -w $SIGNKEY && echo "Key exists" || gpg --batch --import $BUILDTOOLSDIR/build_key.key
 fi
 
 DESCRIPTION="Tyk Identity Broker"
@@ -78,6 +78,6 @@ do
 
         rpmName="tyk-identity-broker-$VERSION-1.${arch/amd64/x86_64}.rpm"
         echo "Signing $arch RPM"
-        $BUILDTOOLSDIR/rpm-sign.exp $rpmName
+        $BUILDTOOLSDIR/rpm-sign.sh $rpmName
     fi
 done


### PR DESCRIPTION
This allows us to use the official golang 1.12 images rather than
having to install it by hand on jessie.

rpm-sign.sh is on BuddyFS/build_tools.