### PR TITLE
Avoid goroutine panics if gateway/dashboard is not running

### DIFF
--- a/tyk-api/tyk_api.go
+++ b/tyk-api/tyk_api.go
@@ -145,7 +145,7 @@ func (t *TykAPI) DispatchDashboard(target Endpoint, method string, usercode stri
 	response, reqErr := c.Do(newRequest)
 
 	if reqErr != nil {
-		return []byte{}, response.StatusCode, reqErr
+		return []byte{}, http.StatusInternalServerError, reqErr
 	}
 
 	retBody, bErr := t.readBody(response)
@@ -191,7 +191,7 @@ func (t *TykAPI) DispatchDashboardSuper(target Endpoint, method string, body io.
 	response, reqErr := c.Do(newRequest)
 
 	if reqErr != nil {
-		return []byte{}, response.StatusCode, reqErr
+		return []byte{}, http.StatusInternalServerError, reqErr
 	}
 
 	retBody, bErr := t.readBody(response)
@@ -229,7 +229,7 @@ func (t *TykAPI) DispatchGateway(target Endpoint, method string, body io.Reader,
 	response, reqErr := c.Do(newRequest)
 
 	if reqErr != nil {
-		return []byte{}, response.StatusCode, reqErr
+		return []byte{}, http.StatusInternalServerError, reqErr
 	}
 
 	retBody, bErr := t.readBody(response)


### PR DESCRIPTION
Even if client.Do request fails, we are accessing response Code. 
According to http docs, 
`A non-nil Response with a non-nil error only occurs when CheckRedirect fails, and even then the returned Response.Body is already closed.`
which is never going to happen in our case.