### PR TITLE
Add support for specifying user group id

### DIFF
--- a/tap/profile.go
+++ b/tap/profile.go
@@ -18,6 +18,9 @@ type Profile struct {
 	IdentityHandlerConfig interface{}
 	ProviderConstraints   ProfileConstraint
 	ReturnURL             string
+	DefaultUserGroupID    string
+	CustomUserGroupField  string
+	UserGroupMapping      map[string]string
 }
 
 // Certain providers can have constraints, this object sets out those constraints. E.g. Domain: "tyk.io" will limit


### PR DESCRIPTION
Fix https://github.com/TykTechnologies/tyk-identity-broker/issues/32

You can set static value via `DefaultGroupID` or dynamic value based on field of oAuth/OpenID scope using `CustomUserGroupField` and `UserGroupMapping` fields. Example:

```
{
  "DefaultUserGroupID": "<default-user-group>",
  "CustomUserGroupField": "scope",
  "UserGroupMapping": {
    "admin": "<admin-group-id>",
    "analytics": "<analytics-group-id>"
  }
}
```