### PR TITLE
Fix Redis SSL fields

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/TykTechnologies/tyk-identity-broker/tothic"
 	"io/ioutil"
+
+	"github.com/TykTechnologies/tyk-identity-broker/tothic"
 
 	"github.com/TykTechnologies/tyk-identity-broker/tyk-api"
 	"github.com/kelseyhightower/envconfig"
@@ -12,12 +13,14 @@ import (
 var failCount int
 
 type IdentityBackendSettings struct {
-	MaxIdle       int
-	MaxActive     int
-	Database      int
-	Password      string
-	EnableCluster bool
-	Hosts         map[string]string
+	MaxIdle               int
+	MaxActive             int
+	Database              int
+	Password              string
+	EnableCluster         bool
+	Hosts                 map[string]string
+	UseSSL                bool
+	SSLInsecureSkipVerify bool
 }
 
 // Configuration holds all configuration settings for TAP


### PR DESCRIPTION
Redis SSL fields aren't populated when calling `newRedisClusterPool`, this fixes the issue, the following configuration now works:
```json
{
    "Secret": "test-secret",
    "HttpServerOptions": {
        "UseSSL": false,      
        "CertFile": "./certs/server.pem",
        "KeyFile": "./certs/server.key"
    },
	"BackEnd": {
		"Name": "redis",
        "ProfileBackendSettings": {},
		"IdentityBackendSettings": {
            "Hosts" : {
                "localhost": "6379"
            },
            "UseSSL": true,
            "SSLInsecureSkipVerify": true,
            "Password": "testpassword",
            "Database": 0,
            "EnableCluster": false,
            "MaxIdle": 1000,
            "MaxActive": 2000
        }
	},
	"TykAPISettings": {
        "GatewayConfig": {
            "Endpoint": "http://localhost",
            "Port": "80",
            "AdminSecret": "54321"
        },
        "DashboardConfig": {
            "Endpoint": "http://localhost",
            "Port": "3000",
            "AdminSecret": "12345"
        }
    }
}
```