### PR TITLE
Fill rawData attributes for LDAP

### DIFF
--- a/providers/active_directory.go
+++ b/providers/active_directory.go
@@ -231,6 +231,8 @@ func (s *ADProvider) getUserData(username string, password string) (goth.User, e
 		if j.Name == s.config.LDAPLastNameAttribute {
 			thisUser.LastName = j.Values[0]
 		}
+		
+		thisUser.RawData[j.Name] = j.Values[0]
 	}
 
 	if !emailFound {


### PR DESCRIPTION
Now you can use attributes like `CustomUserGroupField`, since they read from custom fields. 