### PR TITLE
Fix broken compatibility reported in 84

### DIFF
--- a/tap/identity-handlers/tyk_handler.go
+++ b/tap/identity-handlers/tyk_handler.go
@@ -191,8 +191,15 @@ func (t *TykIdentityHandler) CreateIdentity(i interface{}) (string, error) {
 		GroupID:      groupID,
 	}
 
-	returnVal, ssoEndpoint, retErr := t.API.CreateSSONonce(t.dashboardUserAPICred, accessRequest)
 
+	credentials := t.dashboardUserAPICred
+	tykHandlerLogger.Info("valor de credential inicial: ", credentials)
+	if credentials == "" {
+		credentials = t.API.DashboardConfig.AdminSecret
+		tykHandlerLogger.Info("valor de credential actualizado: ", credentials)
+	}
+
+	returnVal, ssoEndpoint, retErr := t.API.CreateSSONonce(credentials, accessRequest)
 	tykHandlerLogger.WithField("return_value", returnVal).Debugf("Returned from %s endpoint", ssoEndpoint)
 	if retErr != nil {
 		tykHandlerLogger.WithField("return_value", returnVal).Error("API Response error: ", retErr)

--- a/tap/identity-handlers/tyk_handler.go
+++ b/tap/identity-handlers/tyk_handler.go
@@ -193,10 +193,8 @@ func (t *TykIdentityHandler) CreateIdentity(i interface{}) (string, error) {
 
 
 	credentials := t.dashboardUserAPICred
-	tykHandlerLogger.Info("valor de credential inicial: ", credentials)
 	if credentials == "" {
 		credentials = t.API.DashboardConfig.AdminSecret
-		tykHandlerLogger.Info("valor de credential actualizado: ", credentials)
 	}
 
 	returnVal, ssoEndpoint, retErr := t.API.CreateSSONonce(credentials, accessRequest)


### PR DESCRIPTION
In this PR is related to the bug reported in #84 

So, we needed a solution for those cases when IdentityHandlerConfig. DashboardCredential is not present in the profile definition. The solution would be to use `t.API.DashboardConfig.AdminSecret` in order to provide a valid authorization header.

If currently the request goes to `/api/sso` and in these cases then we use `t.API.DashboardConfig.AdminSecret` should we then redirect to `/admin/sso` ?