### PR TITLE
Set log format

### DIFF
--- a/data_loader/data-loader.go
+++ b/data_loader/data-loader.go
@@ -1,12 +1,13 @@
 package data_loader
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/TykTechnologies/tyk-identity-broker/configuration"
+	logger "github.com/TykTechnologies/tyk-identity-broker/log"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
 	"gopkg.in/mgo.v2"
 )
 
+var log = logger.Get()
 var dataLogger = log.WithField("prefix", "TIB DATA LOADER")
 
 // DataLoader is an interface that defines how data is loaded from a source into a AuthRegisterBackend interface store
@@ -16,11 +17,11 @@ type DataLoader interface {
 	Flush(tap.AuthRegisterBackend) error
 }
 
-func CreateMongoLoaderFromConnection(db *mgo.Database)DataLoader{
+func CreateMongoLoaderFromConnection(db *mgo.Database) DataLoader {
 	var dataLoader DataLoader
 
 	dataLogger.Info("Set mongo loader for TIB")
-	dataLoader = &MongoLoader{Db:db}
+	dataLoader = &MongoLoader{Db: db}
 
 	return dataLoader
 }
@@ -37,26 +38,26 @@ func CreateDataLoader(config configuration.Configuration, ProfileFilename *strin
 	}
 
 	switch storageType {
-		case configuration.MONGO:
-			dataLoader = &MongoLoader{}
+	case configuration.MONGO:
+		dataLoader = &MongoLoader{}
 
-			mongoConf := config.Storage.MongoConf
-			dialInfo, err := MongoDialInfo(mongoConf.MongoURL, mongoConf.MongoUseSSL, mongoConf.MongoSSLInsecureSkipVerify)
-			if err != nil {
-				dataLogger.Error("Error getting mongo settings: " + err.Error())
-				return nil, err
-			}
-			loaderConf = MongoLoaderConf{
-				DialInfo: dialInfo,
-			}
-		default:
-			//default: FILE
-			dataLoader = &FileLoader{}
-			//pDir := path.Join(config.ProfileDir, *ProfileFilename)
-			loaderConf = configuration.FileLoaderConf{
-				FileName:   *ProfileFilename,
-				ProfileDir: config.ProfileDir,
-			}
+		mongoConf := config.Storage.MongoConf
+		dialInfo, err := MongoDialInfo(mongoConf.MongoURL, mongoConf.MongoUseSSL, mongoConf.MongoSSLInsecureSkipVerify)
+		if err != nil {
+			dataLogger.Error("Error getting mongo settings: " + err.Error())
+			return nil, err
+		}
+		loaderConf = MongoLoaderConf{
+			DialInfo: dialInfo,
+		}
+	default:
+		//default: FILE
+		dataLoader = &FileLoader{}
+		//pDir := path.Join(config.ProfileDir, *ProfileFilename)
+		loaderConf = configuration.FileLoaderConf{
+			FileName:   *ProfileFilename,
+			ProfileDir: config.ProfileDir,
+		}
 	}
 
 	err := dataLoader.Init(loaderConf)

--- a/log/log.go
+++ b/log/log.go
@@ -26,11 +26,6 @@ func init() {
 	rawLog.Formatter = new(RawFormatter)
 }
 
-func SetFormatter(newFormatter logrus.TextFormatter){
-	log.Formatter = newFormatter
-}
-
-
 func Get() *logrus.Logger {
 	switch strings.ToLower(os.Getenv("TYK_LOGLEVEL")) {
 	case "error":

--- a/log/log.go
+++ b/log/log.go
@@ -18,15 +18,18 @@ func (f *RawFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func init() {
-	log.Info("set format")
 	formatter := new(prefixed.TextFormatter)
 	formatter.TimestampFormat = `Jan 02 15:04:05`
 	formatter.FullTimestamp = true
 
 	log.Formatter = formatter
 	rawLog.Formatter = new(RawFormatter)
-	log.Info("formate set")
 }
+
+func SetFormatter(newFormatter logrus.TextFormatter){
+	log.Formatter = newFormatter
+}
+
 
 func Get() *logrus.Logger {
 	switch strings.ToLower(os.Getenv("TYK_LOGLEVEL")) {

--- a/log/log.go
+++ b/log/log.go
@@ -18,13 +18,14 @@ func (f *RawFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func init() {
-
+	log.Info("set format")
 	formatter := new(prefixed.TextFormatter)
 	formatter.TimestampFormat = `Jan 02 15:04:05`
 	formatter.FullTimestamp = true
 
 	log.Formatter = formatter
 	rawLog.Formatter = new(RawFormatter)
+	log.Info("formate set")
 }
 
 func Get() *logrus.Logger {

--- a/log/log.go
+++ b/log/log.go
@@ -18,7 +18,12 @@ func (f *RawFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func init() {
-	log.Formatter = new(prefixed.TextFormatter)
+
+	formatter := new(prefixed.TextFormatter)
+	formatter.TimestampFormat = `Jan 02 15:04:05`
+	formatter.FullTimestamp = true
+
+	log.Formatter = formatter
 	rawLog.Formatter = new(RawFormatter)
 }
 


### PR DESCRIPTION
Added a proper format to the logger and not leeave it as default. It was presenting logs like:

`INFO[0000] Loaded profiles from Mongo                    prefix="TIB DATA LOADER"`

So, some information as timestamp is missing there, this PR fix that and now the logs printed looks like:

`[Feb 20 10:38:00]  INFO TIB DATA LOADER: Loaded profiles from Mongo`