### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Similar to Google or Twitter auth, you can configure TIB to work with any OpenID
 By default, TIB uses the value of the subject field, returned by UserInfo Endpoint, to generate userId for Dashboard SSO. 
 Please ensure that your Identity Provider is not returning `URL` in subject field. If that's the case you should specify another field which uniquely identifies the user. You can specify the field name by setting `CustomUserIDField` in profile.json file.
 
-For Portal SSO, TIB uses the email scope field.  Some OpenID providers return this claim by default, but not all, in which case the “openid email” scope claim needs to be included, as per the example above.
+TIB can also be configured to use the `openid email` claim.  This claim must be requested for Portal SSO to work, but it can also be used for Dashboard SSO.  Some OpenID providers return this claim by default, but not all, in which case the `openid email` claim needs to be included, as per the example above.
 
 If you are getting 403 error, it can be that your OpenID provider requires providing client_id and secret_id via token url instead of basic http auth, and you need to add `"DisableAuthHeader": true` option to your provider configuration in "UseProviders" section.
 

--- a/README.md
+++ b/README.md
@@ -485,8 +485,10 @@ Similar to Google or Twitter auth, you can configure TIB to work with any OpenID
 	},
 ```
 
-By default, TIB uses value of subject field, returned by UserInfo Endpoint, to generate userId. 
+By default, TIB uses the value of the subject field, returned by UserInfo Endpoint, to generate userId for Dashboard SSO. 
 Please ensure that your Identity Provider is not returning `URL` in subject field. If that's the case you should specify another field which uniquely identifies the user. You can specify the field name by setting `CustomUserIDField` in profile.json file.
+
+For Portal SSO, TIB uses the email scope field.  Some OpenID providers return this claim by default, but not all, in which case the “openid email” scope claim needs to be included, as per the example above.
 
 If you are getting 403 error, it can be that your OpenID provider requires providing client_id and secret_id via token url instead of basic http auth, and you need to add `"DisableAuthHeader": true` option to your provider configuration in "UseProviders" section.
 


### PR DESCRIPTION
As per the example OIDC profiles.json, make it clear that the "openid email" scope claim may be required for Portal SSO.