### PR TITLE
Add ability to receive logger from external app

### DIFF
--- a/Initializer/initializer.go
+++ b/Initializer/initializer.go
@@ -10,7 +10,7 @@ import (
 )
 
 var log = logger.Get()
-var initializerLogger = log.WithField("prefix", "INITIALIZER")
+var initializerLogger = log.WithField("prefix", "TIB INITIALIZER")
 
 // initBackend: Get our backend to use from configs files, new backends must be registered here
 func InitBackend(profileBackendConfiguration interface{}, identityBackendConfiguration interface{})(tap.AuthRegisterBackend,tap.AuthRegisterBackend) {
@@ -39,7 +39,9 @@ func CreateBackendFromRedisConn(db redis.UniversalClient, keyPrefix string) tap.
 func SetLogger(newLogger *logrus.Logger){
 	logger.SetLogger(newLogger)
 	log = newLogger
+
 	initializerLogger = &logrus.Entry{Logger:log}
+	initializerLogger = initializerLogger.Logger.WithField("prefix", "TIB INITIALIZER")
 }
 
 func CreateInMemoryBackend() tap.AuthRegisterBackend  {

--- a/Initializer/initializer.go
+++ b/Initializer/initializer.go
@@ -5,6 +5,8 @@ import (
 	logger "github.com/TykTechnologies/tyk-identity-broker/log"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
 	"github.com/go-redis/redis"
+	"github.com/sirupsen/logrus"
+
 )
 
 var log = logger.Get()
@@ -26,13 +28,17 @@ func InitBackend(profileBackendConfiguration interface{}, identityBackendConfigu
 
 // CreateBackendFromRedisConn: creates a redis backend from an existent redis Connection
 func CreateBackendFromRedisConn(db redis.UniversalClient, keyPrefix string) tap.AuthRegisterBackend {
-	logger.SetLogger(logger.GetRaw())
 	redisBackend := &backends.RedisBackend{KeyPrefix: keyPrefix}
 
 	initializerLogger.Info("Initializing Identity Cache")
 	redisBackend.SetDb(db)
 
 	return redisBackend
+}
+
+func SetLogger(newLogger *logrus.Logger){
+	logger.SetLogger(newLogger)
+	log = newLogger
 }
 
 func CreateInMemoryBackend() tap.AuthRegisterBackend  {

--- a/Initializer/initializer.go
+++ b/Initializer/initializer.go
@@ -26,7 +26,7 @@ func InitBackend(profileBackendConfiguration interface{}, identityBackendConfigu
 
 // CreateBackendFromRedisConn: creates a redis backend from an existent redis Connection
 func CreateBackendFromRedisConn(db redis.UniversalClient, keyPrefix string) tap.AuthRegisterBackend {
-
+	logger.SetLogger(logger.GetRaw())
 	redisBackend := &backends.RedisBackend{KeyPrefix: keyPrefix}
 
 	initializerLogger.Info("Initializing Identity Cache")

--- a/Initializer/initializer.go
+++ b/Initializer/initializer.go
@@ -39,6 +39,7 @@ func CreateBackendFromRedisConn(db redis.UniversalClient, keyPrefix string) tap.
 func SetLogger(newLogger *logrus.Logger){
 	logger.SetLogger(newLogger)
 	log = newLogger
+	initializerLogger = &logrus.Entry{Logger:log}
 }
 
 func CreateInMemoryBackend() tap.AuthRegisterBackend  {

--- a/backends/in_memory.go
+++ b/backends/in_memory.go
@@ -8,12 +8,13 @@ import (
 	"errors"
 	"sync"
 
-	logger "github.com/TykTechnologies/tyk-identity-broker/log"
+	"github.com/TykTechnologies/tyk-identity-broker/log"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
+	"github.com/sirupsen/logrus"
 )
 
-var log = logger.Get()
-var inMemoryLogger = log.WithField("prefix", "IN-MEMORY STORE")
+var logger = log.Get()
+var inMemoryLogger = logger.WithField("prefix", "TIB IN-MEMORY STORE")
 
 // InMemoryBackend implements tap.AuthRegisterBackend to store profile configs in memory
 type InMemoryBackend struct {
@@ -23,6 +24,10 @@ type InMemoryBackend struct {
 
 // Init will create the initial in-memory store structures
 func (m *InMemoryBackend) Init(config interface{}) {
+	logger = log.Get()
+	inMemoryLogger = &logrus.Entry{Logger:logger}
+	inMemoryLogger = inMemoryLogger.Logger.WithField("prefix", "TIB IN-MEMORY STORE")
+
 	inMemoryLogger.Info("Initialised")
 	m.kv = make(map[string]interface{})
 	m.lock = sync.RWMutex{}

--- a/backends/in_memory.go
+++ b/backends/in_memory.go
@@ -14,7 +14,8 @@ import (
 )
 
 var logger = log.Get()
-var inMemoryLogger = logger.WithField("prefix", "TIB IN-MEMORY STORE")
+var inMemoryLogTag = "TIB IN-MEMORY STORE"
+var inMemoryLogger = logger.WithField("prefix", inMemoryLogTag)
 
 // InMemoryBackend implements tap.AuthRegisterBackend to store profile configs in memory
 type InMemoryBackend struct {
@@ -26,7 +27,7 @@ type InMemoryBackend struct {
 func (m *InMemoryBackend) Init(config interface{}) {
 	logger = log.Get()
 	inMemoryLogger = &logrus.Entry{Logger:logger}
-	inMemoryLogger = inMemoryLogger.Logger.WithField("prefix", "TIB IN-MEMORY STORE")
+	inMemoryLogger = inMemoryLogger.Logger.WithField("prefix", inMemoryLogTag)
 
 	inMemoryLogger.Info("Initialised")
 	m.kv = make(map[string]interface{})

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -11,7 +11,8 @@ import (
 	"time"
 )
 
-var redisLogger = logger.WithField("prefix", "TIB REDIS STORE")
+var redisLoggerTag = "TIB REDIS STORE"
+var redisLogger = logger.WithField("prefix", redisLoggerTag)
 
 type RedisConfig struct {
 	MaxIdle               int

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -3,13 +3,15 @@ package backends
 import (
 	"crypto/tls"
 	"encoding/json"
-	"strconv"
-	"time"
+	"github.com/TykTechnologies/tyk-identity-broker/log"
 
 	"github.com/go-redis/redis"
+	"github.com/sirupsen/logrus"
+	"strconv"
+	"time"
 )
 
-var redisLogger = log.WithField("prefix", "REDIS STORE")
+var redisLogger = logger.WithField("prefix", "TIB REDIS STORE")
 
 type RedisConfig struct {
 	MaxIdle               int
@@ -114,6 +116,10 @@ func (r *RedisBackend) Init(config interface{}) {
 
 // SetDb from existent connection
 func (r *RedisBackend) SetDb(db redis.UniversalClient) {
+	logger = log.Get()
+	redisLogger = &logrus.Entry{Logger:logger}
+	redisLogger = redisLogger.Logger.WithField("prefix", "TIB REDIS STORE")
+
 	r.db = db
 	redisLogger.Info("Set DB")
 }

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -14,7 +14,8 @@ import (
 
 var failCount int
 var log = logger.Get()
-var mainLogger = log.WithField("prefix", "CONFIG")
+var mainLoggerTag = "CONFIG"
+var mainLogger = log.WithField("prefix", mainLoggerTag)
 
 const (
 	MONGO = "mongo"
@@ -82,7 +83,7 @@ func LoadConfig(filePath string, conf *Configuration) {
 
 	log = logger.Get()
 	mainLogger = &logrus.Entry{Logger:log}
-	mainLogger = mainLogger.Logger.WithField("prefix", "TIB CONFIG")
+	mainLogger = mainLogger.Logger.WithField("prefix", mainLoggerTag)
 
 	configuration, err := ioutil.ReadFile(filePath)
 	if err != nil {

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/TykTechnologies/tyk-identity-broker/tyk-api"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/sirupsen/logrus"
 )
+
 
 var failCount int
 var log = logger.Get()
@@ -77,6 +79,11 @@ type Configuration struct {
 
 //LoadConfig will load the config from a file
 func LoadConfig(filePath string, conf *Configuration) {
+
+	log = logger.Get()
+	mainLogger = &logrus.Entry{Logger:log}
+	mainLogger = mainLogger.Logger.WithField("prefix", "TIB CONFIG")
+
 	configuration, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		mainLogger.Error("Couldn't load configuration file: ", err)

--- a/data_loader/data-loader.go
+++ b/data_loader/data-loader.go
@@ -1,12 +1,14 @@
 package data_loader
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/TykTechnologies/tyk-identity-broker/configuration"
+	logger "github.com/TykTechnologies/tyk-identity-broker/log"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/mgo.v2"
 )
 
+var log = logger.Get()
 var dataLogger = log.WithField("prefix", "TIB DATA LOADER")
 
 // DataLoader is an interface that defines how data is loaded from a source into a AuthRegisterBackend interface store
@@ -18,6 +20,10 @@ type DataLoader interface {
 
 func CreateMongoLoaderFromConnection(db *mgo.Database)DataLoader{
 	var dataLoader DataLoader
+
+	log = logger.Get()
+	dataLogger = &logrus.Entry{Logger:log}
+	dataLogger = dataLogger.Logger.WithField("prefix", "TIB DATA LOADER")
 
 	dataLogger.Info("Set mongo loader for TIB")
 	dataLoader = &MongoLoader{Db:db}

--- a/data_loader/data-loader.go
+++ b/data_loader/data-loader.go
@@ -9,7 +9,8 @@ import (
 )
 
 var log = logger.Get()
-var dataLogger = log.WithField("prefix", "TIB DATA LOADER")
+var dataLoaderLoggerTag = "TIB DATA LOADER"
+var dataLogger = log.WithField("prefix", dataLoaderLoggerTag)
 
 // DataLoader is an interface that defines how data is loaded from a source into a AuthRegisterBackend interface store
 type DataLoader interface {
@@ -18,13 +19,16 @@ type DataLoader interface {
 	Flush(tap.AuthRegisterBackend) error
 }
 
+func reloadDataLoaderLogger(){
+	log = logger.Get()
+	dataLogger = &logrus.Entry{Logger:log}
+	dataLogger = dataLogger.Logger.WithField("prefix", dataLoaderLoggerTag)
+}
+
 func CreateMongoLoaderFromConnection(db *mgo.Database)DataLoader{
 	var dataLoader DataLoader
 
-	log = logger.Get()
-	dataLogger = &logrus.Entry{Logger:log}
-	dataLogger = dataLogger.Logger.WithField("prefix", "TIB DATA LOADER")
-
+	reloadDataLoaderLogger()
 	dataLogger.Info("Set mongo loader for TIB")
 	dataLoader = &MongoLoader{Db:db}
 
@@ -34,6 +38,7 @@ func CreateMongoLoaderFromConnection(db *mgo.Database)DataLoader{
 func CreateDataLoader(config configuration.Configuration, ProfileFilename *string) (DataLoader, error) {
 	var dataLoader DataLoader
 	var loaderConf interface{}
+	reloadDataLoaderLogger()
 
 	//default storage
 	storageType := configuration.FILE

--- a/data_loader/mongo-loader.go
+++ b/data_loader/mongo-loader.go
@@ -2,8 +2,8 @@ package data_loader
 
 import (
 	"crypto/tls"
-	"github.com/sirupsen/logrus"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/mgo.v2"
 	"net"
 	"time"

--- a/error/error.go
+++ b/error/error.go
@@ -3,11 +3,12 @@ package error
 import (
 	"encoding/json"
 	"fmt"
+	logger "github.com/TykTechnologies/tyk-identity-broker/log"
 	"github.com/sirupsen/logrus"
 	"net/http"
 )
 
-var log = logrus.New()
+var log = logger.Get()
 
 // APIErrorMessage is an object that defines when a generic error occurred
 type APIErrorMessage struct {

--- a/log/log.go
+++ b/log/log.go
@@ -36,6 +36,10 @@ func Get() *logrus.Logger {
 	return log
 }
 
+func SetLogger(logger *logrus.Logger){
+	log = logger
+}
+
 func GetRaw() *logrus.Logger {
 	return rawLog
 }

--- a/log/log.go
+++ b/log/log.go
@@ -18,7 +18,11 @@ func (f *RawFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func init() {
-	log.Formatter = new(prefixed.TextFormatter)
+	formatter := new(prefixed.TextFormatter)
+	formatter.TimestampFormat = `Jan 02 15:04:05`
+	formatter.FullTimestamp = true
+
+	log.Formatter = formatter
 	rawLog.Formatter = new(RawFormatter)
 }
 

--- a/providers/proxy.go
+++ b/providers/proxy.go
@@ -66,6 +66,7 @@ func (p *ProxyProvider) respondFailure(rw http.ResponseWriter, r *http.Request) 
 
 func (p *ProxyProvider) Handle(rw http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 	// copy the request to a target
+
 	target, tErr := url.Parse(p.config.TargetHost)
 	if tErr != nil {
 		proxyLogger.WithFields(logrus.Fields{

--- a/providers/tapProvider.go
+++ b/providers/tapProvider.go
@@ -3,13 +3,12 @@ package providers
 import (
 	"encoding/json"
 	"errors"
-	"github.com/sirupsen/logrus"
 	"github.com/TykTechnologies/tyk-identity-broker/constants"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
 	identityHandlers "github.com/TykTechnologies/tyk-identity-broker/tap/identity-handlers"
 	"github.com/TykTechnologies/tyk-identity-broker/tyk-api"
+	"github.com/sirupsen/logrus"
 )
-
 
 // return a provider based on the name of the provider type, add new providers here
 func GetTAProvider(conf tap.Profile,handler tyk.TykAPI, identityKeyStore tap.AuthRegisterBackend) (tap.TAProvider, error) {

--- a/tap/identity-handlers/dummy_handler.go
+++ b/tap/identity-handlers/dummy_handler.go
@@ -6,18 +6,27 @@ import (
 	"fmt"
 	logger "github.com/TykTechnologies/tyk-identity-broker/log"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
+	"github.com/sirupsen/logrus"
 	"net/http"
+	"sync"
 )
 
 var log = logger.Get()
 var DummyLogTag string = "[DUMMY ID HANDLER]"
-var dummyLogger = log.WithField("prefix", "DUMMY ID HANDLER")
+var onceReloadDummyLogger sync.Once
+var dummyLogger = log.WithField("prefix", DummyLogTag)
 
 // DummyIdentityHandler is a dummy hndler, use for testing
 type DummyIdentityHandler struct{}
 
 // Init will set up the configuration of the handler
 func (d DummyIdentityHandler) Init(conf interface{}) error {
+	//if an external logger was set, then lets reload it to inherit those configs
+	onceReloadDummyLogger.Do(func() {
+		log = logger.Get()
+		dummyLogger = &logrus.Entry{Logger:log}
+		dummyLogger = dummyLogger.Logger.WithField("prefix", DummyLogTag)
+	})
 	return nil
 }
 


### PR DESCRIPTION
In order to maintain the same format of the logs in dashboard, we needed the ability to receive a logger as param and use that one, also, we need to ensure that if the logger was set, then tib packages will reload their logger to get the new configs.

Some of the changes performed in this PR includes a function to reload the logger inside a `sync.Once` statement, this was made in this way to only reload the logger the minimum as possible.  The reason why not only receive log configs as param is that its not only about format of the information but the Log Level can be set in the main app and we need to inherit that as well.

This PR unblocks: https://github.com/TykTechnologies/tyk-analytics/pull/1884

Ticket related: https://github.com/TykTechnologies/tyk-identity-broker/issues/97

**Pull Requests Information**
These 2 PR's should be merged in tandem, as Tyk-Analytics use a function of TIB added in its respective PR. The Pr's are:

https://github.com/TykTechnologies/tyk-identity-broker/pull/96
https://github.com/TykTechnologies/tyk-analytics/pull/1884

After merge https://github.com/TykTechnologies/tyk-identity-broker/pull/96 we will need to revendor TIB in Analytics.
