### PR TITLE
SAML provider for TIB

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -7,8 +7,8 @@ const (
 
 //providers
 const (
-    SocialProvider = "SocialProvider"
-    ADProvider = "ADProvider"
-    ProxyProvider = "ProxyProvider"
+	SocialProvider = "SocialProvider"
+	ADProvider     = "ADProvider"
+	ProxyProvider  = "ProxyProvider"
+	SAMLProvider   = "SAMLProvider"
 )
-

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"errors"
+	"net/http"
+
 	"github.com/TykTechnologies/tyk-identity-broker/constants"
 	"github.com/TykTechnologies/tyk-identity-broker/providers"
-	"net/http"
 
 	tykerrors "github.com/TykTechnologies/tyk-identity-broker/error"
 	"github.com/gorilla/mux"
 )
-
 
 // Returns a profile ID
 func getId(req *http.Request) (string, error) {
@@ -24,6 +24,43 @@ func getId(req *http.Request) (string, error) {
 
 }
 
+func HandleAuthSAMLLogon(w http.ResponseWriter, r *http.Request) {
+	//thisId, idErr := getId(r)
+	//if idErr != nil {
+	//	tykerrors.HandleError(constants.HandlerLogTag, "Could not retrieve ID", idErr, 400, w, r)
+	//	return
+	//}
+	//
+	//thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
+	//if err != nil {
+	//	tykerrors.HandleError(constants.HandlerLogTag, err.Message, err.Error, err.Code, w, r)
+	//	return
+	//}
+
+	return
+}
+
+//does nothing - extend tap interface
+func HandleSAMLMetadata(w http.ResponseWriter, r *http.Request) {
+	thisId, idErr := getId(r)
+	if idErr != nil {
+		tykerrors.HandleError(constants.HandlerLogTag, "Could not retrieve ID", idErr, 400, w, r)
+		return
+	}
+
+	thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
+	if err != nil {
+		tykerrors.HandleError(constants.HandlerLogTag, err.Message, err.Error, err.Code, w, r)
+		return
+	}
+	switch thisIdentityProvider.Name() {
+	case "SAMLProvider":
+	default:
+		return
+	}
+
+}
+
 // HandleAuth is the main entry point handler for any profile (i.e. /auth/:profile-id/:provider)
 func HandleAuth(w http.ResponseWriter, r *http.Request) {
 
@@ -33,7 +70,7 @@ func HandleAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	thisIdentityProvider, err := providers.GetTapProfile( AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
+	thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
 	if err != nil {
 		return
 	}
@@ -52,12 +89,11 @@ func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	thisIdentityProvider, err := providers.GetTapProfile( AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
+	thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
 	if err != nil {
 		tykerrors.HandleError(constants.HandlerLogTag, err.Message, err.Error, err.Code, w, r)
 		return
 	}
-
 	thisIdentityProvider.HandleCallback(w, r, tykerrors.HandleError)
 	return
 }
@@ -65,4 +101,3 @@ func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 func HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
-

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -24,43 +24,6 @@ func getId(req *http.Request) (string, error) {
 
 }
 
-func HandleAuthSAMLLogon(w http.ResponseWriter, r *http.Request) {
-	//thisId, idErr := getId(r)
-	//if idErr != nil {
-	//	tykerrors.HandleError(constants.HandlerLogTag, "Could not retrieve ID", idErr, 400, w, r)
-	//	return
-	//}
-	//
-	//thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
-	//if err != nil {
-	//	tykerrors.HandleError(constants.HandlerLogTag, err.Message, err.Error, err.Code, w, r)
-	//	return
-	//}
-
-	return
-}
-
-//does nothing - extend tap interface
-func HandleSAMLMetadata(w http.ResponseWriter, r *http.Request) {
-	thisId, idErr := getId(r)
-	if idErr != nil {
-		tykerrors.HandleError(constants.HandlerLogTag, "Could not retrieve ID", idErr, 400, w, r)
-		return
-	}
-
-	thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
-	if err != nil {
-		tykerrors.HandleError(constants.HandlerLogTag, err.Message, err.Error, err.Code, w, r)
-		return
-	}
-	switch thisIdentityProvider.Name() {
-	case "SAMLProvider":
-	default:
-		return
-	}
-
-}
-
 // HandleAuth is the main entry point handler for any profile (i.e. /auth/:profile-id/:provider)
 func HandleAuth(w http.ResponseWriter, r *http.Request) {
 
@@ -100,4 +63,20 @@ func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 
 func HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
+}
+
+func HandleMetadata(w http.ResponseWriter, r *http.Request) {
+	thisId, idErr := getId(r)
+	if idErr != nil {
+		tykerrors.HandleError(constants.HandlerLogTag, "Could not retrieve ID", idErr, 400, w, r)
+		return
+	}
+
+	thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
+	if err != nil {
+		tykerrors.HandleError(constants.HandlerLogTag, err.Message, err.Error, err.Code, w, r)
+		return
+	}
+	thisIdentityProvider.HandleMetadata(w, r)
+	return
 }

--- a/main.go
+++ b/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"net/http"
+	"strconv"
+
 	"github.com/TykTechnologies/tyk-identity-broker/Initializer"
 	"github.com/TykTechnologies/tyk-identity-broker/configuration"
 	"github.com/TykTechnologies/tyk-identity-broker/data_loader"
-	"net/http"
-	"strconv"
 
 	errors "github.com/TykTechnologies/tyk-identity-broker/error"
 	logger "github.com/TykTechnologies/tyk-identity-broker/log"
@@ -72,6 +73,10 @@ func main() {
 	p := mux.NewRouter()
 	p.Handle("/auth/{id}/{provider}/callback", http.HandlerFunc(HandleAuthCallback))
 	p.Handle("/auth/{id}/{provider}", http.HandlerFunc(HandleAuth))
+
+	//saml specific handlers
+	p.Handle("/auth/{id}/{provider}/signon", http.HandlerFunc(HandleAuthSAMLLogon))
+	p.Handle("/auth/{id}/{provider}/metadata", http.HandlerFunc(HandleSAMLMetadata))
 
 	p.Handle("/api/profiles/{id}", IsAuthenticated(http.HandlerFunc(HandleGetProfile))).Methods("GET")
 	p.Handle("/api/profiles/{id}", IsAuthenticated(http.HandlerFunc(HandleAddProfile))).Methods("POST")

--- a/main.go
+++ b/main.go
@@ -73,10 +73,7 @@ func main() {
 	p := mux.NewRouter()
 	p.Handle("/auth/{id}/{provider}/callback", http.HandlerFunc(HandleAuthCallback))
 	p.Handle("/auth/{id}/{provider}", http.HandlerFunc(HandleAuth))
-
-	//saml specific handlers
-	p.Handle("/auth/{id}/{provider}/signon", http.HandlerFunc(HandleAuthSAMLLogon))
-	p.Handle("/auth/{id}/{provider}/metadata", http.HandlerFunc(HandleSAMLMetadata))
+	p.Handle("/auth/{id}/saml/metadata", http.HandlerFunc(HandleMetadata))
 
 	p.Handle("/api/profiles/{id}", IsAuthenticated(http.HandlerFunc(HandleGetProfile))).Methods("GET")
 	p.Handle("/api/profiles/{id}", IsAuthenticated(http.HandlerFunc(HandleAddProfile))).Methods("POST")

--- a/providers/active_directory.go
+++ b/providers/active_directory.go
@@ -20,7 +20,7 @@ import (
 )
 
 var onceReloadADLogger sync.Once
-var ADLogTag =  "AD AUTH"
+var ADLogTag = "AD AUTH"
 var ADLogger = log.WithField("prefix", ADLogTag)
 
 // ADProvider is an auth delegation provider for LDAP protocol
@@ -101,7 +101,7 @@ func (s *ADProvider) Init(handler tap.IdentityHandler, profile tap.Profile, conf
 	//if an external logger was set, then lets reload it to inherit those configs
 	onceReloadADLogger.Do(func() {
 		log = logger.Get()
-		ADLogger = &logrus.Entry{Logger:log}
+		ADLogger = &logrus.Entry{Logger: log}
 		ADLogger = ADLogger.Logger.WithField("prefix", ADLogTag)
 	})
 
@@ -262,7 +262,7 @@ func (s *ADProvider) getUserData(username string, password string) (goth.User, e
 
 // Handle is a delegate for the Http Handler used by the generic inbound handler, it will extract the username
 // and password from the request and atempt to bind tot he AD host.
-func (s *ADProvider) Handle(w http.ResponseWriter, r *http.Request,pathParams map[string]string) {
+func (s *ADProvider) Handle(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 	s.connect()
 
 	username := r.FormValue("username")
@@ -340,5 +340,10 @@ func (s *ADProvider) checkConstraints(user interface{}) error {
 func (s *ADProvider) HandleCallback(w http.ResponseWriter, r *http.Request, onError func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request)) {
 
 	ADLogger.Warning("Callback not implemented for provider")
+
+}
+
+func (s *ADProvider) HandleMetadata(http.ResponseWriter, *http.Request) {
+	ADLogger.Warning("metadata not implemented for provider")
 
 }

--- a/providers/proxy.go
+++ b/providers/proxy.go
@@ -4,11 +4,6 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/Jeffail/gabs"
-	logger "github.com/TykTechnologies/tyk-identity-broker/log"
-	"github.com/TykTechnologies/tyk-identity-broker/tap"
-	"github.com/markbates/goth"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +11,12 @@ import (
 	"net/url"
 	"regexp"
 	"sync"
+
+	"github.com/Jeffail/gabs"
+	logger "github.com/TykTechnologies/tyk-identity-broker/log"
+	"github.com/TykTechnologies/tyk-identity-broker/tap"
+	"github.com/markbates/goth"
+	"github.com/sirupsen/logrus"
 )
 
 var onceReloadProxyLogger sync.Once
@@ -44,7 +45,7 @@ func (p *ProxyProvider) Init(handler tap.IdentityHandler, profile tap.Profile, c
 	//if a logger was set, then lets reload it to inherit those configs
 	onceReloadProxyLogger.Do(func() {
 		log = logger.Get()
-		proxyLogger = &logrus.Entry{Logger:log}
+		proxyLogger = &logrus.Entry{Logger: log}
 		proxyLogger = proxyLogger.Logger.WithField("prefix", proxyLogTag)
 	})
 
@@ -188,4 +189,8 @@ func (p *ProxyProvider) Handle(rw http.ResponseWriter, r *http.Request, pathPara
 
 func (p *ProxyProvider) HandleCallback(http.ResponseWriter, *http.Request, func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request)) {
 	return
+}
+
+func (s *ProxyProvider) HandleMetadata(http.ResponseWriter, *http.Request) {
+	proxyLogger.Warning("metadata not implemented for provider")
 }

--- a/providers/saml.go
+++ b/providers/saml.go
@@ -1,0 +1,278 @@
+package providers
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/markbates/goth"
+
+	"github.com/crewjam/saml"
+
+	"github.com/crewjam/saml/samlsp"
+
+	logger "github.com/TykTechnologies/tyk-identity-broker/log"
+	"github.com/sirupsen/logrus"
+
+	"github.com/TykTechnologies/tyk-identity-broker/tap"
+)
+
+var onceReloadSAMLLogger sync.Once
+var SAMLLogTag = "SAML AUTH"
+var SAMLLogger = log.WithField("prefix", SAMLLogTag)
+
+type SAMLProvider struct {
+	handler tap.IdentityHandler
+	config  SAMLConfig
+	profile tap.Profile
+	m       *samlsp.Middleware
+}
+
+var middleware *samlsp.Middleware
+
+type SAMLConfig struct {
+	MetadataURL     string
+	CertFile        string
+	KeyFile         string
+	CallbackBaseURL string
+}
+
+func (s *SAMLProvider) Init(handler tap.IdentityHandler, profile tap.Profile, config []byte) error {
+	//if an external logger was set, then lets reload it to inherit those configs
+	onceReloadADLogger.Do(func() {
+		log = logger.Get()
+		ADLogger = &logrus.Entry{Logger: log}
+		ADLogger = ADLogger.Logger.WithField("prefix", ADLogTag)
+	})
+
+	s.handler = handler
+	s.profile = profile
+	unmarshallErr := json.Unmarshal(config, &s.config)
+
+	if unmarshallErr != nil {
+		return unmarshallErr
+	}
+	s.initialiseSAMLMiddleware()
+
+	return nil
+}
+
+func (s *SAMLProvider) Name() string {
+	return "SAMLProvider"
+}
+
+func (s *SAMLProvider) ProviderType() tap.ProviderType {
+	return tap.REDIRECT_PROVIDER
+}
+
+func (s *SAMLProvider) UseCallback() bool {
+	return true
+}
+
+func (s *SAMLProvider) initialiseSAMLMiddleware() {
+	if middleware == nil {
+
+		log.Debug("Initialising middleware SAML")
+		//needs to match the signing cert if IDP
+		keyPair, err := tls.LoadX509KeyPair("myservice.cert", "myservice.key")
+		if err != nil {
+			panic(err) // TODO handle error
+		}
+		log.Debug("loaded cert and key")
+		keyPair.Leaf, err = x509.ParseCertificate(keyPair.Certificate[0])
+		if err != nil {
+			panic(err) // TODO handle error
+		}
+
+		idpMetadataURL, err := url.Parse(s.config.MetadataURL)
+		if err != nil {
+			panic(err) // TODO handle error
+		}
+		log.Debugf("metadataurl is: %v", idpMetadataURL.String())
+
+		rootURL, err := url.Parse("https://c22192bb.ngrok.io/auth/azure-saml/")
+		if err != nil {
+			panic(err) // TODO handle error
+		}
+
+		httpClient := http.DefaultClient
+
+		metadata, err := samlsp.FetchMetadata(context.TODO(), httpClient, *idpMetadataURL)
+		if err != nil {
+			panic(err)
+		}
+
+		log.Debugf("Root URL: %v", rootURL.String())
+
+		opts := samlsp.Options{
+			URL: *rootURL,
+			Key: keyPair.PrivateKey.(*rsa.PrivateKey),
+		}
+
+		metadataURL := rootURL.ResolveReference(&url.URL{Path: "saml/metadata"})
+		acsURL := rootURL.ResolveReference(&url.URL{Path: "saml/callback"})
+		sloURL := rootURL.ResolveReference(&url.URL{Path: "saml/slo"})
+
+		log.Debugf("SP metadata URL: %v", metadataURL.String())
+		log.Debugf("SP acs URL: %v", acsURL.String())
+
+		var forceAuthn = false
+
+		sp := saml.ServiceProvider{
+			EntityID:          metadataURL.String(),
+			Key:               keyPair.PrivateKey.(*rsa.PrivateKey),
+			Certificate:       keyPair.Leaf,
+			MetadataURL:       *metadataURL,
+			AcsURL:            *acsURL,
+			SloURL:            *sloURL,
+			IDPMetadata:       metadata,
+			ForceAuthn:        &forceAuthn,
+			AllowIDPInitiated: true,
+		}
+
+		middleware = &samlsp.Middleware{
+			ServiceProvider: sp,
+			Binding:         "",
+			OnError:         samlsp.DefaultOnError,
+			Session:         samlsp.DefaultSessionProvider(opts),
+		}
+		middleware.RequestTracker = samlsp.DefaultRequestTracker(opts, &middleware.ServiceProvider)
+	}
+
+}
+
+func (s *SAMLProvider) Handle(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+	s.m = middleware
+	// If we try to redirect when the original request is the ACS URL we'll
+	// end up in a loop. This is a programming error, so we panic here. In
+	// general this means a 500 to the user, which is preferable to a
+	// redirect loop.
+	//log.Debug(s.m)
+	if r.URL.Path == s.m.ServiceProvider.AcsURL.Path {
+		panic("don't wrap Middleware with RequireAccount")
+	}
+
+	var binding, bindingLocation string
+	if s.m.Binding != "" {
+		binding = s.m.Binding
+		bindingLocation = s.m.ServiceProvider.GetSSOBindingLocation(binding)
+	} else {
+		binding = saml.HTTPRedirectBinding
+		bindingLocation = s.m.ServiceProvider.GetSSOBindingLocation(binding)
+		if bindingLocation == "" {
+			binding = saml.HTTPPostBinding
+			bindingLocation = s.m.ServiceProvider.GetSSOBindingLocation(binding)
+		}
+	}
+	log.Debugf("Binding: %v", binding)
+	log.Debugf("BindingLocation: %v", bindingLocation)
+
+	authReq, err := s.m.ServiceProvider.MakeAuthenticationRequest(bindingLocation)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// relayState is limited to 80 bytes but also must be integrity protected.
+	// this means that we cannot use a JWT because it is way to long. Instead
+	// we set a signed cookie that encodes the original URL which we'll check
+	// against the SAML response when we get it.
+	relayState, err := s.m.RequestTracker.TrackRequest(w, r, authReq.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if binding == saml.HTTPRedirectBinding {
+		redirectURL := authReq.Redirect(relayState)
+		w.Header().Add("Location", redirectURL.String())
+		w.WriteHeader(http.StatusFound)
+		return
+	}
+	if binding == saml.HTTPPostBinding {
+		w.Header().Add("Content-Security-Policy", ""+
+			"default-src; "+
+			"script-src 'sha256-AjPdJSbZmeWHnEc5ykvJFay8FTWeTeRbs9dutfZ0HqE='; "+
+			"reflected-xss block; referrer no-referrer;")
+		w.Header().Add("Content-type", "text/html")
+		w.Write([]byte(`<!DOCTYPE html><html><body>`))
+		w.Write(authReq.Post(relayState))
+		w.Write([]byte(`</body></html>`))
+		return
+	}
+	panic("not reached")
+}
+
+func (s *SAMLProvider) HandleCallback(w http.ResponseWriter, r *http.Request, onError func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request)) {
+	s.m = middleware
+	fmt.Println(r.Cookies())
+	//log.Debug(s.m)
+	err := r.ParseForm()
+	if err != nil {
+		log.Error(err)
+	}
+
+	var possibleRequestIDs = make([]string, 0)
+	if s.m.ServiceProvider.AllowIDPInitiated {
+		log.Debug("allowing IDP initiated ID")
+		possibleRequestIDs = append(possibleRequestIDs, "")
+	}
+
+	trackedRequests := s.m.RequestTracker.GetTrackedRequests(r)
+	for _, tr := range trackedRequests {
+		log.Debug(tr)
+		possibleRequestIDs = append(possibleRequestIDs, tr.SAMLRequestID)
+	}
+	log.Debugf("Possible request IDs: %v", possibleRequestIDs)
+	assertion, err := s.m.ServiceProvider.ParseResponse(r, possibleRequestIDs)
+	if err != nil {
+		s.m.OnError(w, r, err)
+		return
+	}
+	rawData := make(map[string]interface{}, 0)
+	for _, v := range assertion.AttributeStatements {
+		for _, att := range v.Attributes {
+			fmt.Printf("attribute name: %v\n", att.Name)
+			rawData[att.Name] = ""
+			for _, vals := range att.Values {
+				rawData[att.Name] = vals.Value
+				fmt.Printf("vals.value: %v\n ", vals.Value)
+			}
+
+		}
+	}
+
+	var email string
+	name := rawData["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"].(string) + " " +
+		rawData["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"].(string)
+
+	if _, ok := rawData["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]; ok {
+		email = rawData["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"].(string)
+	}
+
+	if _, ok := rawData["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"]; ok {
+		email = rawData["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"].(string)
+	}
+
+	//fmt.Println(rawData["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"])
+
+	//s.m.CreateSessionFromAssertion(w, r, assertion)
+
+	thisUser := goth.User{
+		UserID:   name,
+		Email:    email,
+		Provider: "SAMLProvider",
+		RawData:  rawData,
+	}
+	s.handler.CompleteIdentityAction(w, r, thisUser, s.profile)
+}
+
+func (s *SAMLProvider) getCallBackURL() string {
+	return s.config.CallbackBaseURL + "/auth/" + s.profile.ID + "/" + "saml" + "/callback"
+}

--- a/providers/saml.go
+++ b/providers/saml.go
@@ -9,6 +9,7 @@ import (
 	"encoding/xml"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/markbates/goth"
@@ -236,15 +237,17 @@ func (s *SAMLProvider) HandleCallback(w http.ResponseWriter, r *http.Request, on
 		return
 	}
 	rawData := make(map[string]interface{}, 0)
+	var str strings.Builder
 	for _, v := range assertion.AttributeStatements {
 		for _, att := range v.Attributes {
 			SAMLLogger.Debugf("attribute name: %v\n", att.Name)
 			rawData[att.Name] = ""
 			for _, vals := range att.Values {
-				rawData[att.Name] = vals.Value
+				str.WriteString(vals.Value + " ")
 				SAMLLogger.Debugf("vals.value: %v\n ", vals.Value)
 			}
-
+			rawData[att.Name] = strings.TrimSuffix(str.String(), " ")
+			str.Reset()
 		}
 	}
 

--- a/providers/saml.go
+++ b/providers/saml.go
@@ -51,7 +51,7 @@ type SAMLConfig struct {
 
 func (s *SAMLProvider) Init(handler tap.IdentityHandler, profile tap.Profile, config []byte) error {
 	//if an external logger was set, then lets reload it to inherit those configs
-	onceReloadADLogger.Do(func() {
+	onceReloadSAMLLogger.Do(func() {
 		log = logger.Get()
 		SAMLLogger = &logrus.Entry{Logger: log}
 		SAMLLogger = SAMLLogger.Logger.WithField("prefix", SAMLLogTag)
@@ -88,7 +88,7 @@ func (s *SAMLProvider) initialiseSAMLMiddleware() {
 		//needs to match the signing cert if IDP
 		keyPair, err := tls.LoadX509KeyPair(s.config.CertFile, s.config.KeyFile)
 		if err != nil {
-			log.Errorf("Error loading keypair: %v", err)
+			SAMLLogger.Errorf("Error loading keypair: %v", err)
 		}
 
 		keyPair.Leaf, err = x509.ParseCertificate(keyPair.Certificate[0])

--- a/providers/social.go
+++ b/providers/social.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"sync"
 
+	"net/http"
+	"strings"
+
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/bitbucket"
 	"github.com/markbates/goth/providers/digitalocean"
@@ -19,8 +22,6 @@ import (
 	"github.com/markbates/goth/providers/salesforce"
 	"github.com/markbates/goth/providers/twitter"
 	"golang.org/x/oauth2"
-	"net/http"
-	"strings"
 
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
 	"github.com/TykTechnologies/tyk-identity-broker/toth"
@@ -85,7 +86,7 @@ func (s *Social) Init(handler tap.IdentityHandler, profile tap.Profile, config [
 	//if an external logger was set, then lets reload it to inherit those configs
 	onceReloadADLogger.Do(func() {
 		log = logger.Get()
-		socialLogger = &logrus.Entry{Logger:log}
+		socialLogger = &logrus.Entry{Logger: log}
 		socialLogger = socialLogger.Logger.WithField("prefix", SocialLogTag)
 	})
 
@@ -135,7 +136,7 @@ func (s *Social) Init(handler tap.IdentityHandler, profile tap.Profile, config [
 				socialLogger.Error(err)
 				return err
 			}
-			
+
 			gProv.SkipUserInfoRequest = provider.SkipUserInfoRequest
 
 			// See https://godoc.org/golang.org/x/oauth2#RegisterBrokenAuthHeaderProvider
@@ -200,4 +201,8 @@ func (s *Social) HandleCallback(w http.ResponseWriter, r *http.Request, onError 
 
 func (s *Social) getCallBackURL(provider string) string {
 	return s.config.CallbackBaseURL + "/auth/" + s.profile.ID + "/" + provider + "/callback"
+}
+
+func (s *Social) HandleMetadata(http.ResponseWriter, *http.Request) {
+	socialLogger.Warning("metadata not implemented for provider")
 }

--- a/providers/tapProvider.go
+++ b/providers/tapProvider.go
@@ -22,7 +22,7 @@ func GetTAProvider(conf tap.Profile, handler tyk.TykAPI, identityKeyStore tap.Au
 		thisProvider = &ADProvider{}
 	case constants.ProxyProvider:
 		thisProvider = &ProxyProvider{}
-	case "SAMLProvider":
+	case constants.SAMLProvider:
 		thisProvider = &SAMLProvider{}
 	default:
 		return nil, errors.New("invalid provider name")

--- a/providers/tapProvider.go
+++ b/providers/tapProvider.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"encoding/json"
 	"errors"
+
 	"github.com/TykTechnologies/tyk-identity-broker/constants"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
 	identityHandlers "github.com/TykTechnologies/tyk-identity-broker/tap/identity-handlers"
@@ -11,10 +12,9 @@ import (
 )
 
 // return a provider based on the name of the provider type, add new providers here
-func GetTAProvider(conf tap.Profile,handler tyk.TykAPI, identityKeyStore tap.AuthRegisterBackend) (tap.TAProvider, error) {
+func GetTAProvider(conf tap.Profile, handler tyk.TykAPI, identityKeyStore tap.AuthRegisterBackend) (tap.TAProvider, error) {
 
 	var thisProvider tap.TAProvider
-
 	switch conf.ProviderName {
 	case constants.SocialProvider:
 		thisProvider = &Social{}
@@ -22,6 +22,8 @@ func GetTAProvider(conf tap.Profile,handler tyk.TykAPI, identityKeyStore tap.Aut
 		thisProvider = &ADProvider{}
 	case constants.ProxyProvider:
 		thisProvider = &ProxyProvider{}
+	case "SAMLProvider":
+		thisProvider = &SAMLProvider{}
 	default:
 		return nil, errors.New("invalid provider name")
 	}
@@ -34,7 +36,7 @@ func GetTAProvider(conf tap.Profile,handler tyk.TykAPI, identityKeyStore tap.Aut
 }
 
 // Maps an identity handler from an Action type, register new Identity Handlers and methods here
-func getIdentityHandler(name tap.Action,handler tyk.TykAPI, identityKeyStore tap.AuthRegisterBackend) tap.IdentityHandler {
+func getIdentityHandler(name tap.Action, handler tyk.TykAPI, identityKeyStore tap.AuthRegisterBackend) tap.IdentityHandler {
 	var thisIdentityHandler tap.IdentityHandler
 
 	switch name {
@@ -47,7 +49,7 @@ func getIdentityHandler(name tap.Action,handler tyk.TykAPI, identityKeyStore tap
 	return thisIdentityHandler
 }
 
-func GetTapProfile(AuthConfigStore, identityKeyStore tap.AuthRegisterBackend, id string,tykHandler tyk.TykAPI) (tap.TAProvider, *tap.HttpError) {
+func GetTapProfile(AuthConfigStore, identityKeyStore tap.AuthRegisterBackend, id string, tykHandler tyk.TykAPI) (tap.TAProvider, *tap.HttpError) {
 
 	thisProfile := tap.Profile{}
 	log.WithField("prefix", constants.HandlerLogTag).Debug("--> Looking up profile ID: ", id)
@@ -62,9 +64,9 @@ func GetTapProfile(AuthConfigStore, identityKeyStore tap.AuthRegisterBackend, id
 		}
 	}
 
-	thisIdentityProvider, providerErr := GetTAProvider(thisProfile,tykHandler,identityKeyStore)
+	thisIdentityProvider, providerErr := GetTAProvider(thisProfile, tykHandler, identityKeyStore)
 	if providerErr != nil {
-		return  nil, &tap.HttpError{
+		return nil, &tap.HttpError{
 			Message: "Could not initialise provider",
 			Code:    400,
 			Error:   providerErr,

--- a/tap/identity-handlers/tyk_handler.go
+++ b/tap/identity-handlers/tyk_handler.go
@@ -199,6 +199,8 @@ func (t *TykIdentityHandler) CreateIdentity(i interface{}) (string, error) {
 		}
 	}
 
+	tykHandlerLogger.Debugf("The GroupID %s is used for SSO: ", groupID)
+
 	accessRequest := SSOAccessData{
 		ForSection:   thisModule,
 		OrgID:        t.profile.OrgID,

--- a/tap/ta_provider.go
+++ b/tap/ta_provider.go
@@ -15,4 +15,5 @@ type TAProvider interface {
 	UseCallback() bool
 	Handle(http.ResponseWriter, *http.Request, map[string]string)
 	HandleCallback(http.ResponseWriter, *http.Request, func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request))
+	HandleMetadata(http.ResponseWriter, *http.Request)
 }

--- a/tap/ta_provider.go
+++ b/tap/ta_provider.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 )
 
-
 // TAProvider is an interface that defines an actual handler for a specific authentication provider. It can wrap
 // largert libraries (such as Goth for social), or individual pass-throughs such as LDAP.
 type TAProvider interface {


### PR DESCRIPTION
Fixes https://github.com/TykTechnologies/tyk-identity-broker/issues/7

Docs PR here: https://github.com/TykTechnologies/tyk-docs/pull/1256


- Tested with AzureAD and samltest.id

- [x]  Redirect 
- [x] POST
- [x] Claim mapping
- [x] docs


Docs: 

**SSO with SAML and Tyk**

SAML authentication is a way for a service provider, such as the Tyk Dashboard or Portal, to assert the Identity of a User via a third party.

Tyk Identity Broker can act as the go-between for the Tyk Dashboard and Portal and a third party identity provider. Tyk Identity broker can also interpret and pass along information about the user who is logging in such as Name, Email and group or role metadata for enforcing role based access control in the Tyk Dashboard.

The provider config for SAML has the following values that can be configured in a Profile:

`SAMLBaseURL` - The host of TIB that will be used in the metadata document for the Service Provider. This will form part of the metadata URL used as the Entity ID by the IDP. The redirects configured in the IDP must match the expected Host and URI configured in the metadata document made available by Tyk Identity Broker.

`FailureRedirect` - Where to redirect failed login requests.

`IDPMetaDataURL` - The metadata URL of your IDP which will provide Tyk Identity Broker with information about the IDP such as EntityID, Endpoints (Single Sign On Service Endpoint, Single Logout Service Endpoint), its public X.509 cert, NameId Format, Organization info and Contact info.

This metadata XML can be signed providing a public X.509 cert and the private key.     

`CertFile` - An X.509 certificate for signing your requests to the IDP

 'KeyFile' - A private key for signing your requests to the IDP

`ForceAuthentication` - Ignore any session held by the IDP and force re-login every request.

`SAMLEmailClaim` - Key for looking up the email claim in the SAML assertion form the IDP. Defaults to: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`

`SAMLForenameClaim` - Key for looking up the forename claim in the SAML assertion form the IDP. Defaults to: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/forename`

`SAMLSurnameClaim` - Key for looking up the surname claim in the SAML assertion form the IDP. Defaults to: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`

Example profile configuration:

```
{
    "ActionType": "GenerateOrLoginUserProfile",
    "ID": "saml-sso-login",
    "OrgID": "{YOUR_ORGANISATION_ID}",
    "CustomEmailField": "",
    "IdentityHandlerConfig": {
        "DashboardCredential": "{DASHBOARD_USER_API_KEY}"
    },
    "ProviderConfig": {
        "SAMLBaseURL": "https://{HOST}",
        "FailureRedirect": "http://{DASHBOARD_HOST}:{PORT}/?fail=true",
        "IDPMetaDataURL": "{IDP_METADATA_URL}",
        "CertFile":"myservice.cert",
        "KeyFile": "myservice.key",
        "ForceAuthentication": false,
        "SAMLEmailClaim": "",
        "SAMLForenameClaim": "",
        "SAMLSurnameClaim": ""
    },
    "ProviderName": "SAMLProvider",
    "ReturnURL": "http://{DASHBOARD_URL}:{PORT}/tap",
    "Type": "redirect"
}
```