### PR TITLE
Adding SAML role support for Dashboard Users Groups. Example:

### DIFF
--- a/providers/saml.go
+++ b/providers/saml.go
@@ -9,6 +9,7 @@ import (
 	"encoding/xml"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/markbates/goth"
@@ -236,15 +237,17 @@ func (s *SAMLProvider) HandleCallback(w http.ResponseWriter, r *http.Request, on
 		return
 	}
 	rawData := make(map[string]interface{}, 0)
+	var str strings.Builder
 	for _, v := range assertion.AttributeStatements {
 		for _, att := range v.Attributes {
 			SAMLLogger.Debugf("attribute name: %v\n", att.Name)
 			rawData[att.Name] = ""
 			for _, vals := range att.Values {
-				rawData[att.Name] = vals.Value
+				str.WriteString(vals.Value + " ")
 				SAMLLogger.Debugf("vals.value: %v\n ", vals.Value)
 			}
-
+			rawData[att.Name] = strings.TrimSuffix(str.String(), " ")
+			str.Reset()
 		}
 	}
 

--- a/tap/identity-handlers/tyk_handler.go
+++ b/tap/identity-handlers/tyk_handler.go
@@ -199,6 +199,8 @@ func (t *TykIdentityHandler) CreateIdentity(i interface{}) (string, error) {
 		}
 	}
 
+	tykHandlerLogger.Debugf("The GroupID %s is used for SSO: ", groupID)
+
 	accessRequest := SSOAccessData{
 		ForSection:   thisModule,
 		OrgID:        t.profile.OrgID,


### PR DESCRIPTION
profiles.json

```
{
...
 "CustomUserGroupField": "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
    "UserGroupMapping": {
      "7149b3c0-5e5d-48b3-a42a-c73ded0bc232": "5f034003ed3dc300012e48a0",
      "ab776d34-1d4c-4ee0-9f4b-9a9cae029f4e": "5f033fa1ed3dc300012e489f"
    }
...
}
```