### PR TITLE
skipTLSVerify while consuming dashboard api {do not merge}

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func main() {
 		mainLogger.Info("--> Using SSL (https) for TIB")
 		cert, err := tls.LoadX509KeyPair(config.HttpServerOptions.CertFile, config.HttpServerOptions.KeyFile)
 
+		log.Info("key file:", config.HttpServerOptions.KeyFile)
 		if err != nil {
 			mainLogger.WithError(err).Error("loading cert file")
 			return
@@ -118,6 +119,11 @@ func createListener(port int, tlsConfig *tls.Config) (listener net.Listener) {
 
 	if tlsConfig != nil {
 		listener, err = tls.Listen("tcp", addr, tlsConfig)
+
+		// to consume Dash api, then we skip as well the verification in the client side
+		tr := &http.Transport{TLSClientConfig: tlsConfig}
+		c := &http.Client{Transport: tr}
+		tyk.SetHttpClient(c)
 	} else {
 		listener, err = net.Listen("tcp", addr)
 	}

--- a/main.go
+++ b/main.go
@@ -94,7 +94,6 @@ func main() {
 		mainLogger.Info("--> Using SSL (https) for TIB")
 		cert, err := tls.LoadX509KeyPair(config.HttpServerOptions.CertFile, config.HttpServerOptions.KeyFile)
 
-		log.Info("key file:", config.HttpServerOptions.KeyFile)
 		if err != nil {
 			mainLogger.WithError(err).Error("loading cert file")
 			return

--- a/tyk-api/tyk_api.go
+++ b/tyk-api/tyk_api.go
@@ -22,6 +22,7 @@ var onceReloadTykApiLogger sync.Once
 var log = logger.Get()
 var tykApiLogTag = "TYK_API"
 var tykAPILogger = log.WithField("prefix", tykApiLogTag)
+var httpClient = &http.Client{}
 
 type Endpoint string   // A type for endpoints
 type TykAPIName string // A type for Tyk API names (e.g. dashboard, gateway)
@@ -148,6 +149,10 @@ func ReloadLogger(){
 	})
 }
 
+func SetHttpClient(c *http.Client){
+	httpClient = c
+}
+
 // DispatchDashboard dispatches a request to the dashboard API and handles the response
 func (t *TykAPI) DispatchDashboard(target Endpoint, method string, usercode string, body io.Reader) ([]byte, int, error) {
 	//if user set custom dispatcher then lets use it (internal tib)
@@ -165,8 +170,8 @@ func (t *TykAPI) DispatchDashboard(target Endpoint, method string, usercode stri
 	}
 
 	newRequest.Header.Add("authorization", usercode)
-	c := &http.Client{}
-	response, reqErr := c.Do(newRequest)
+	//c := &http.Client{}
+	response, reqErr := httpClient.Do(newRequest)
 
 	if reqErr != nil {
 		return []byte{}, http.StatusInternalServerError, reqErr
@@ -215,8 +220,8 @@ func (t *TykAPI) DispatchDashboardSuper(target Endpoint, method string, body io.
 	}
 
 	newRequest.Header.Add("admin-auth", t.DashboardConfig.AdminSecret)
-	c := &http.Client{}
-	response, reqErr := c.Do(newRequest)
+//	c := &http.Client{}
+	response, reqErr := httpClient.Do(newRequest)
 
 	if reqErr != nil {
 		return []byte{}, http.StatusInternalServerError, reqErr
@@ -253,8 +258,8 @@ func (t *TykAPI) DispatchGateway(target Endpoint, method string, body io.Reader,
 
 	newRequest.Header.Add("x-tyk-authorization", t.GatewayConfig.AdminSecret)
 	newRequest.Header.Add("content-type", ctype)
-	c := &http.Client{}
-	response, reqErr := c.Do(newRequest)
+	//c := &http.Client{}
+	response, reqErr := httpClient.Do(newRequest)
 
 	if reqErr != nil {
 		return []byte{}, http.StatusInternalServerError, reqErr

--- a/tyk-api/tyk_api.go
+++ b/tyk-api/tyk_api.go
@@ -161,7 +161,6 @@ func (t *TykAPI) DispatchDashboard(target Endpoint, method string, usercode stri
 	}
 
 	preparedEndpoint := t.DashboardConfig.Endpoint + ":" + t.DashboardConfig.Port + string(target)
-
 	tykAPILogger.Debug("Calling: ", preparedEndpoint)
 	newRequest, err := http.NewRequest(method, preparedEndpoint, body)
 	if err != nil {
@@ -170,7 +169,6 @@ func (t *TykAPI) DispatchDashboard(target Endpoint, method string, usercode stri
 	}
 
 	newRequest.Header.Add("authorization", usercode)
-	//c := &http.Client{}
 	response, reqErr := httpClient.Do(newRequest)
 
 	if reqErr != nil {
@@ -220,7 +218,6 @@ func (t *TykAPI) DispatchDashboardSuper(target Endpoint, method string, body io.
 	}
 
 	newRequest.Header.Add("admin-auth", t.DashboardConfig.AdminSecret)
-//	c := &http.Client{}
 	response, reqErr := httpClient.Do(newRequest)
 
 	if reqErr != nil {
@@ -258,7 +255,6 @@ func (t *TykAPI) DispatchGateway(target Endpoint, method string, body io.Reader,
 
 	newRequest.Header.Add("x-tyk-authorization", t.GatewayConfig.AdminSecret)
 	newRequest.Header.Add("content-type", ctype)
-	//c := &http.Client{}
 	response, reqErr := httpClient.Do(newRequest)
 
 	if reqErr != nil {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
for POCs is need sometimes to set skipTLSVerify:true and therefore have the ability to use self signed certificates.

## Related Issue
https://github.com/TykTechnologies/tyk-identity-broker/issues/102

## Motivation and Context
Give solution to https://github.com/TykTechnologies/tyk-identity-broker/issues/102

## How This Has Been Tested
- Ran dashboard and TIB in HTTPS
- in TIB config file set `config.HttpServerOptions.SSLInsecureSkipVerify:true`
- Call TIB with `curl --location -vk --request POST 'https://localhost:3010/auth/ldap-for-sso-dashboard/ADProvider?username=read-only-admin&password=password'
- Nonce is created and a URL to login to dev portal comes in the response

## Screenshots (if appropriate)

Response:
```
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 3010 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=co; ST=bgta; L=bgta; OU=tyk-dashboard; CN=tyk-dashboard; emailAddress=sredny@tyk.io
*  start date: Aug 10 20:10:19 2020 GMT
*  expire date: Aug  8 20:10:19 2030 GMT
*  issuer: C=co; ST=bgta; L=bgta; OU=tyk-dashboard; CN=tyk-dashboard; emailAddress=sredny@tyk.io
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
> POST /auth/ldap-for-sso-dashboard/ADProvider?username=read-only-admin&password=password HTTP/1.1
> Host: localhost:3010
> User-Agent: curl/7.64.1
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Location: http://tyk-portal:3000/sso/?nonce=MTAyZGI1YTUtNmQwZC00ZWJiLTdlODMtODQ5YThlYWY1NDkz
< Date: Mon, 10 Aug 2020 21:46:34 GMT
< Content-Length: 0
```


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
