### PR TITLE
TT-265 when log level is debug, dont panic in saml

### DIFF
--- a/providers/saml.go
+++ b/providers/saml.go
@@ -100,7 +100,6 @@ func (s *SAMLProvider) initialiseSAMLMiddleware() {
 			SAMLLogger.Errorf("Error parsing IDP metadata URL: %v", err)
 		}
 
-		SAMLLogger.Debug("SAML Meta:", idpMetadataURL)
 		SAMLLogger.Debugf("IDPmetadataURL is: %v", idpMetadataURL.String())
 		rootURL, err := url.Parse(s.config.SAMLBaseURL)
 		if err != nil {

--- a/providers/saml.go
+++ b/providers/saml.go
@@ -86,7 +86,7 @@ func (s *SAMLProvider) UseCallback() bool {
 func (s *SAMLProvider) initialiseSAMLMiddleware() {
 	if middleware == nil {
 
-//		SAMLLogger.Debug("Initialising middleware SAML")
+		SAMLLogger.Debug("Initialising middleware SAML")
 		//needs to match the signing cert if IDP
 		certs := CertManager.List([]string{s.config.CertLocation}, certs.CertificateAny)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
When log level is Debug, dont panic when `log.Debug` is called

## Related Issue
https://tyktech.atlassian.net/browse/TT-265

## Motivation and Context
Give solution to https://tyktech.atlassian.net/browse/TT-265

## How This Has Been Tested
- Follow reproduction steps described in ticket

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
