### PR TITLE
Tt 262 move in memory path params to redis 

### DIFF
--- a/backends/in_memory_test.go
+++ b/backends/in_memory_test.go
@@ -22,7 +22,7 @@ func TestInMemoryBackend_GetAndSetKey(t *testing.T) {
 	}
 
 	target := aStruct{}
-	vErr := backend.GetKey(keyName,"", &target)
+	_, vErr := backend.GetKey(keyName,"", &target)
 
 	if vErr != nil {
 		t.Error("Error raised on get key: ", vErr)

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -152,16 +152,8 @@ func (r *RedisBackend) GetKey(key string,orgId string, val interface{}) error {
 		return err
 	}
 
-	// need to marshal so in case that val is string, int, etc we will not have troubles un-marshaling the data
-	// from redis to val
-	data, err := json.Marshal(result)
-	if err != nil {
-		redisLogger.WithError(err).Error("marshalling result from redis")
-		return err
-	}
-
 	// if AuthConfigStore is redis adapter, then redis return string
-	if err = json.Unmarshal(data, &val); err != nil {
+	if err = json.Unmarshal([]byte(result), &val); err != nil {
 		redisLogger.WithError(err).Error("unmarshalling redis result into interface")
 	}
 

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -156,13 +156,13 @@ func (r *RedisBackend) GetKey(key string,orgId string, val interface{}) error {
 	// from redis to val
 	data, err := json.Marshal(result)
 	if err != nil {
-		mongoLogger.WithError(err).Error("marshalling result from redis")
+		redisLogger.WithError(err).Error("marshalling result from redis")
 		return err
 	}
 
 	// if AuthConfigStore is redis adapter, then redis return string
 	if err = json.Unmarshal(data, &val); err != nil {
-		log.Get().Error("error:", err)
+		redisLogger.WithError(err).Error("unmarshalling redis result into interface")
 	}
 
 	return err

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -152,12 +152,20 @@ func (r *RedisBackend) GetKey(key string,orgId string, val interface{}) error {
 		return err
 	}
 
-	// if AuthConfigStore is redis adapter, then redis return string
-	if err := json.Unmarshal([]byte(result), &val); err != nil {
+	// need to marshal so in case that val is string, int, etc we will not have troubles un-marshaling the data
+	// from redis to val
+	data, err := json.Marshal(result)
+	if err != nil {
+		mongoLogger.WithError(err).Error("marshalling result from redis")
 		return err
 	}
 
-	return nil
+	// if AuthConfigStore is redis adapter, then redis return string
+	if err = json.Unmarshal(data, &val); err != nil {
+		log.Get().Error("error:", err)
+	}
+
+	return err
 }
 
 func (r *RedisBackend) hashKey(in string) string {

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -135,7 +135,6 @@ func (r *RedisBackend) SetDb(db redis.UniversalClient) {
 func (r *RedisBackend) SetKey(key string,orgId string, val interface{}) error {
 	db := r.ensureConnection()
 
-	redisLogger.Debug("Setting key=", key)
 	if err := db.Set(r.fixKey(key), val, 0).Err(); err != nil {
 		redisLogger.WithError(err).Debug("Error trying to set value")
 		return err

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -33,13 +33,13 @@ func HandleAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
+	thisIdentityProvider,thisProfile, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
 	if err != nil {
 		return
 	}
 
 	pathParams := mux.Vars(r)
-	thisIdentityProvider.Handle(w, r, pathParams)
+	thisIdentityProvider.Handle(w, r, pathParams, thisProfile)
 	return
 }
 
@@ -52,12 +52,12 @@ func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
+	thisIdentityProvider,thisProfile, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
 	if err != nil {
 		tykerrors.HandleError(constants.HandlerLogTag, err.Message, err.Error, err.Code, w, r)
 		return
 	}
-	thisIdentityProvider.HandleCallback(w, r, tykerrors.HandleError)
+	thisIdentityProvider.HandleCallback(w, r, tykerrors.HandleError, thisProfile)
 	return
 }
 
@@ -72,7 +72,7 @@ func HandleMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	thisIdentityProvider, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
+	thisIdentityProvider,_, err := providers.GetTapProfile(AuthConfigStore, IdentityKeyStore, thisId, TykAPIHandler)
 	if err != nil {
 		tykerrors.HandleError(constants.HandlerLogTag, err.Message, err.Error, err.Code, w, r)
 		return

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -6,6 +6,7 @@ import (
 	logger "github.com/TykTechnologies/tyk-identity-broker/log"
 	"github.com/TykTechnologies/tyk-identity-broker/providers"
 	"github.com/TykTechnologies/tyk-identity-broker/tap"
+	"github.com/TykTechnologies/tyk-identity-broker/tothic"
 	"github.com/TykTechnologies/tyk/certs"
 	"github.com/go-redis/redis"
 	"github.com/sirupsen/logrus"
@@ -66,4 +67,8 @@ func CreateMongoBackend(db *mgo.Database) tap.AuthRegisterBackend {
 	var config interface{}
 	mongoBackend.Init(config)
 	return mongoBackend
+}
+
+func SetConfigHandler(backend tap.AuthRegisterBackend){
+	tothic.SetParamsStoreHandler(backend)
 }

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -16,7 +16,7 @@ import (
 var log = logger.Get()
 var initializerLogger = log.WithField("prefix", "TIB INITIALIZER")
 
-// initBackend: Get our backend to use from configs files, new backends must be registered here
+// initBackend: Get our backend to use from configs files, new back-ends must be registered here
 func InitBackend(profileBackendConfiguration interface{}, identityBackendConfiguration interface{}) (tap.AuthRegisterBackend, tap.AuthRegisterBackend) {
 
 	AuthConfigStore := &backends.InMemoryBackend{}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"github.com/TykTechnologies/tyk-identity-broker/backends"
 	"github.com/TykTechnologies/tyk-identity-broker/configuration"
 	"github.com/TykTechnologies/tyk-identity-broker/data_loader"
 	"github.com/TykTechnologies/tyk-identity-broker/initializer"
@@ -46,6 +47,10 @@ func init() {
 
 	configuration.LoadConfig(*confFile, &config)
 	AuthConfigStore, IdentityKeyStore = initializer.InitBackend(config.BackEnd.ProfileBackendSettings, config.BackEnd.IdentityBackendSettings)
+
+	configStore := &backends.RedisBackend{KeyPrefix: "tib-provider-config-"}
+	configStore.Init(config.BackEnd.IdentityBackendSettings)
+	initializer.SetConfigHandler(configStore)
 
 	TykAPIHandler = config.TykAPISettings
 

--- a/providers/active_directory.go
+++ b/providers/active_directory.go
@@ -262,7 +262,7 @@ func (s *ADProvider) getUserData(username string, password string) (goth.User, e
 
 // Handle is a delegate for the Http Handler used by the generic inbound handler, it will extract the username
 // and password from the request and atempt to bind tot he AD host.
-func (s *ADProvider) Handle(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+func (s *ADProvider) Handle(w http.ResponseWriter, r *http.Request, pathParams map[string]string,profile tap.Profile) {
 	s.connect()
 
 	username := r.FormValue("username")
@@ -337,7 +337,7 @@ func (s *ADProvider) checkConstraints(user interface{}) error {
 }
 
 // HandleCallback is not used
-func (s *ADProvider) HandleCallback(w http.ResponseWriter, r *http.Request, onError func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request)) {
+func (s *ADProvider) HandleCallback(w http.ResponseWriter, r *http.Request, onError func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request), profile tap.Profile) {
 
 	ADLogger.Warning("Callback not implemented for provider")
 

--- a/providers/proxy.go
+++ b/providers/proxy.go
@@ -77,7 +77,7 @@ func (p *ProxyProvider) respondFailure(rw http.ResponseWriter, r *http.Request) 
 	fmt.Fprintf(rw, "Authentication Failed")
 }
 
-func (p *ProxyProvider) Handle(rw http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+func (p *ProxyProvider) Handle(rw http.ResponseWriter, r *http.Request, pathParams map[string]string, profile tap.Profile) {
 	// copy the request to a target
 
 	target, tErr := url.Parse(p.config.TargetHost)
@@ -187,7 +187,7 @@ func (p *ProxyProvider) Handle(rw http.ResponseWriter, r *http.Request, pathPara
 	p.handler.CompleteIdentityAction(rw, r, thisUser, p.profile)
 }
 
-func (p *ProxyProvider) HandleCallback(http.ResponseWriter, *http.Request, func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request)) {
+func (p *ProxyProvider) HandleCallback(http.ResponseWriter, *http.Request, func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request),tap.Profile) {
 	return
 }
 

--- a/providers/saml.go
+++ b/providers/saml.go
@@ -158,7 +158,7 @@ func (s *SAMLProvider) initialiseSAMLMiddleware() {
 
 }
 
-func (s *SAMLProvider) Handle(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+func (s *SAMLProvider) Handle(w http.ResponseWriter, r *http.Request, pathParams map[string]string, profile tap.Profile) {
 	s.m = middleware
 	// If we try to redirect when the original request is the ACS URL we'll
 	// end up in a loop so just fail and error instead
@@ -217,7 +217,7 @@ func (s *SAMLProvider) Handle(w http.ResponseWriter, r *http.Request, pathParams
 	}
 }
 
-func (s *SAMLProvider) HandleCallback(w http.ResponseWriter, r *http.Request, onError func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request)) {
+func (s *SAMLProvider) HandleCallback(w http.ResponseWriter, r *http.Request, onError func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request), profile tap.Profile) {
 	s.m = middleware
 
 	err := r.ParseForm()

--- a/providers/social.go
+++ b/providers/social.go
@@ -153,8 +153,8 @@ func (s *Social) Init(handler tap.IdentityHandler, profile tap.Profile, config [
 }
 
 // Handle is the main callback delegate for the generic auth flow
-func (s *Social) Handle(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
-	tothic.BeginAuthHandler(w, r, &s.toth, pathParams)
+func (s *Social) Handle(w http.ResponseWriter, r *http.Request, pathParams map[string]string, profile tap.Profile) {
+	tothic.BeginAuthHandler(w, r, &s.toth, pathParams, profile)
 }
 
 func (s *Social) checkConstraints(user interface{}) error {
@@ -175,9 +175,9 @@ func (s *Social) checkConstraints(user interface{}) error {
 }
 
 // HandleCallback handles the callback from the OAuth provider
-func (s *Social) HandleCallback(w http.ResponseWriter, r *http.Request, onError func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request)) {
+func (s *Social) HandleCallback(w http.ResponseWriter, r *http.Request, onError func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request), profile tap.Profile) {
 
-	user, err := tothic.CompleteUserAuth(w, r, &s.toth)
+	user, err := tothic.CompleteUserAuth(w, r, &s.toth, profile)
 	if err != nil {
 		fmt.Fprintln(w, err)
 		return

--- a/providers/tapProvider.go
+++ b/providers/tapProvider.go
@@ -49,7 +49,7 @@ func getIdentityHandler(name tap.Action, handler tyk.TykAPI, identityKeyStore ta
 	return thisIdentityHandler
 }
 
-func GetTapProfile(AuthConfigStore, identityKeyStore tap.AuthRegisterBackend, id string, tykHandler tyk.TykAPI) (tap.TAProvider, *tap.HttpError) {
+func GetTapProfile(AuthConfigStore, identityKeyStore tap.AuthRegisterBackend, id string, tykHandler tyk.TykAPI) (tap.TAProvider, tap.Profile, *tap.HttpError) {
 
 	thisProfile := tap.Profile{}
 	log.WithField("prefix", constants.HandlerLogTag).Debug("--> Looking up profile ID: ", id)
@@ -57,7 +57,7 @@ func GetTapProfile(AuthConfigStore, identityKeyStore tap.AuthRegisterBackend, id
 
 	if foundProfileErr != nil {
 		errorMsg := "Profile " + id + " not found"
-		return nil, &tap.HttpError{
+		return nil,thisProfile, &tap.HttpError{
 			Message: errorMsg,
 			Code:    404,
 			Error:   foundProfileErr,
@@ -66,14 +66,14 @@ func GetTapProfile(AuthConfigStore, identityKeyStore tap.AuthRegisterBackend, id
 
 	thisIdentityProvider, providerErr := GetTAProvider(thisProfile, tykHandler, identityKeyStore)
 	if providerErr != nil {
-		return nil, &tap.HttpError{
+		return nil,thisProfile, &tap.HttpError{
 			Message: "Could not initialise provider",
 			Code:    400,
 			Error:   providerErr,
 		}
 	}
 
-	return thisIdentityProvider, nil
+	return thisIdentityProvider,thisProfile, nil
 }
 
 // A hack to marshal a provider conf from map[string]interface{} into a type without type checking, ugly, but effective

--- a/tap/profile.go
+++ b/tap/profile.go
@@ -33,11 +33,16 @@ type ProfileConstraint struct {
 	Group  string
 }
 
-func(m Profile)UnmarshalBinary(data []byte) error{
+func(p Profile)UnmarshalBinary(data []byte) error{
 	// convert data to yours, let's assume its json data
-	return json.Unmarshal(data, m)
+	return json.Unmarshal(data, p)
 }
 
-func (m Profile) MarshalBinary() ([]byte, error) {
-	return json.Marshal(m)
+func (p Profile) MarshalBinary() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+// GetPrefix return prefix for redis
+func (p Profile) GetPrefix() string {
+	return p.OrgID+"-"+p.ID
 }

--- a/tap/ta_provider.go
+++ b/tap/ta_provider.go
@@ -13,7 +13,7 @@ type TAProvider interface {
 	Name() string
 	ProviderType() ProviderType
 	UseCallback() bool
-	Handle(http.ResponseWriter, *http.Request, map[string]string)
-	HandleCallback(http.ResponseWriter, *http.Request, func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request))
+	Handle(http.ResponseWriter, *http.Request, map[string]string, Profile)
+	HandleCallback(http.ResponseWriter, *http.Request, func(tag string, errorMsg string, rawErr error, code int, w http.ResponseWriter, r *http.Request), Profile)
 	HandleMetadata(http.ResponseWriter, *http.Request)
 }

--- a/tothic/tothic.go
+++ b/tothic/tothic.go
@@ -63,8 +63,8 @@ func KeyFromEnv() (key string) {
 }
 
 type pathParam struct {
-	Id       string `json:"id"`
-	Provider string `json:"provider"`
+	Id       string `json:"id,string"`
+	Provider string `json:"provider,string"`
 }
 
 func (p pathParam) UnmarshalBinary(data []byte) error {

--- a/tothic/tothic.go
+++ b/tothic/tothic.go
@@ -63,8 +63,8 @@ func KeyFromEnv() (key string) {
 }
 
 type PathParam struct {
-	Id       string `json:"id,string"`
-	Provider string `json:"provider,string"`
+	Id       string `json:"id"`
+	Provider string `json:"provider"`
 }
 
 func (p PathParam) UnmarshalBinary(data []byte) error {
@@ -95,6 +95,7 @@ func SetPathParams(newPathParams map[string]string, profile tap.Profile) {
 func GetParams(profile tap.Profile) PathParam{
 	params := PathParam{}
 	pathParams.GetKey(profile.GetPrefix(),profile.OrgID,&params)
+	log.Infof("params: %+v",params)
 	return params
 }
 

--- a/tothic/tothic.go
+++ b/tothic/tothic.go
@@ -62,17 +62,17 @@ func KeyFromEnv() (key string) {
 	return
 }
 
-type pathParam struct {
+type PathParam struct {
 	Id       string `json:"id,string"`
 	Provider string `json:"provider,string"`
 }
 
-func (p pathParam) UnmarshalBinary(data []byte) error {
+func (p PathParam) UnmarshalBinary(data []byte) error {
 	// convert data to yours, let's assume its json data
 	return json.Unmarshal(data, p)
 }
 
-func (p pathParam) MarshalBinary() ([]byte, error) {
+func (p PathParam) MarshalBinary() ([]byte, error) {
 	return json.Marshal(p)
 }
 
@@ -83,7 +83,7 @@ func SetPathParams(newPathParams map[string]string, profile tap.Profile) {
 		return
 	}
 
-	params := pathParam{}
+	params := PathParam{}
 	if err := json.Unmarshal(jsonbody, &params); err != nil {
 		return
 	}
@@ -92,8 +92,8 @@ func SetPathParams(newPathParams map[string]string, profile tap.Profile) {
 
 }
 
-func GetParams(profile tap.Profile) pathParam{
-	params := pathParam{}
+func GetParams(profile tap.Profile) PathParam{
+	params := PathParam{}
 	pathParams.GetKey(profile.GetPrefix(),profile.OrgID,&params)
 	return params
 }

--- a/tothic/tothic.go
+++ b/tothic/tothic.go
@@ -63,10 +63,13 @@ func KeyFromEnv() (key string) {
 }
 
 func SetPathParams(newPathParams map[string]string){
-	for k, v := range newPathParams{
+
+	pathParams.SetKey("=================something","",newPathParams)
+	logger.Get().Info("setted from here")
+	/*for k, v := range newPathParams{
 		err:=pathParams.SetKey(k,"",v)
 		log.Error(err)
-	}
+	}*/
 }
 /*
 BeginAuthHandler is a convienence handler for starting the authentication process.
@@ -198,7 +201,7 @@ func getProviderName() (string, error) {
 	if err != nil {
 		log.Error(err)
 	}
-	log.Info("PP:", pathParams)
+
 	if provider == "" {
 		err := pathParams.GetKey(":provider","",provider)
 		if err != nil {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
thotic saves the relation of path params with providers using a map, this was moved to use redis for internal tib so it works ok in internal tib with a load balancer. It also was considered the multi-org environment, hence the implementation of redis keys considering the orgId

## Related Issue
https://tyktech.atlassian.net/browse/TT-262

## Motivation and Context
give solution to https://tyktech.atlassian.net/browse/TT-262

## How This Has Been Tested
- Ran TIB in internal and external tib
- connect internal tib with redis, and check that the full flow works. External TIB also initializes with redis as default
- created 2 social profiles (This PR affects directly the social providers). Was created one for dashboard sso access using github, and another with open-id using azure. Here I attach the profiles:

Using azure:
```
{
            "ID": "open-id-dashboard",
            "OrgID": "my-org-id",
            "ActionType": "GenerateOrLoginUserProfile",
            "ProviderName": "SocialProvider",
            "ProviderConfig": {
                "CallbackBaseURL": "http://localhost:3010",
                "FailureRedirect": "http://localhost:3010/?fail=true",
                "UseProviders": [
                    {
                        "DiscoverURL": "some-discover-url",
                        "Key": "some-key",
                        "Name": "openid-connect",
                        "Scopes": [
                            "openid",
                            "email"
                        ],
                        "Secret": "some-secret"
                    }
                ]
            },
            "IdentityHandlerConfig": {
                "DashboardCredential": "dash-credential"
            },
            "ProviderConstraints": {
                "Domain": "",
                "Group": ""
            },
            "ReturnURL": "http://localhost:3000/tap",
            "DefaultUserGroupID": "",
            "CustomUserGroupField": "",
            "UserGroupMapping": {}
        }
```

Using github: 
```
{
    "ID" : "github-dash-access",
    "OrgID" : "my-org-id",
    "ActionType" : "GenerateOrLoginUserProfile",
    "Type" : "redirect",
    "ProviderName" : "SocialProvider",
    "ProviderConfig" : {
        "CallbackBaseURL" : "https://6f73025f7acd.ngrok.io",
        "FailureRedirect" : "https://6f73025f7acd.ngrok.io/?fail=true",
        "UseProviders" : [ 
            {
                "Key" : "some-key",
                "Name" : "github",
                "Secret" : "some-secret"
            }
        ]
    },
    "ReturnURL" : "https://6f73025f7acd.ngrok.io/tap",
}
```

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
