### PR TITLE
modify host header to match upstream host

### DIFF
--- a/providers/proxy.go
+++ b/providers/proxy.go
@@ -92,6 +92,7 @@ func (p *ProxyProvider) Handle(rw http.ResponseWriter, r *http.Request, pathPara
 	// intercept the response
 	recorder := httptest.NewRecorder()
 	r.URL.Path = ""
+	r.Host = target.Host
 	thisProxy.ServeHTTP(recorder, r)
 
 	if recorder.Code >= 400 {


### PR DESCRIPTION
TIB's proxy flow does not work if any upstream service that verifies Host headers against Expected Host headers will fail, such as the Google Suite APIs.  That's because Tyk does not insert Upstream Host header's into the call like it is supposed to. 