### PR TITLE
[TT-1129] Fix proxy provider with email.

### DIFF
--- a/providers/proxy.go
+++ b/providers/proxy.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"regexp"
 	"sync"
+	"strings
 
 	"github.com/Jeffail/gabs"
 	logger "github.com/TykTechnologies/tyk-identity-broker/log"
@@ -179,6 +180,13 @@ func (p *ProxyProvider) Handle(rw http.ResponseWriter, r *http.Request, pathPara
 		UserID:      uName,
 		Provider:    p.Name(),
 		AccessToken: AccessToken,
+	}
+	
+	// If it is already email
+	if strings.Contains(uName, "@") {
+		thisUser.Email = uName
+	} else {
+		thisUser.Email = uName + "@soSession.com"
 	}
 
 	proxyLogger.Info("Username: ", thisUser.UserID)


### PR DESCRIPTION
## Description
At the moment developer portal access with Proxy provider is broken because Developer SSO requires email.
This PR is relatively simple: if a username is already an email use it, otherwise build it as `uName + "@soSession.com"`

## How This Has Been Tested
@sedkis confirmed it is working

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
