### PR TITLE
packagecloud-action@v1.1 uses the older API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,7 +370,7 @@ jobs:
 
       - name: Push to packagecloud
         id: pc-push
-        uses: TykTechnologies/packagecloud-action@main
+        uses: TykTechnologies/packagecloud-action@v1.1
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
         with:


### PR DESCRIPTION
This should resolve the problem reported in https://tyktech.slack.com/archives/CKARCGLEM/p1642640267066300

https://github.com/TykTechnologies/tyk-identity-broker/runs/4875941393?check_suite_focus=true was the last run.
