### PR TITLE
Merging to release-1.4: upgraded TIB to use storage v1.0.2 (#276)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Jeffail/gabs v1.4.0
-	github.com/TykTechnologies/storage v1.0.1
+	github.com/TykTechnologies/storage v1.0.2
 	github.com/TykTechnologies/tyk v1.9.2-0.20211217130848-b04d51712be7
 	github.com/crewjam/saml v0.4.12
 	github.com/go-ldap/ldap/v3 v3.2.3

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/TykTechnologies/leakybucket v0.0.0-20170301023702-71692c943e3c/go.mod
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465 h1:A2gBjoX8aF0G3GHEpHyj2f0ixuPkCgcGqmPdKHSkW+0=
 github.com/TykTechnologies/murmur3 v0.0.0-20180602122059-1915e687e465/go.mod h1:sqH/SPFr11m9cahie7ulBuBX9TOhfBX1sp+qf9jh3Vg=
 github.com/TykTechnologies/openid2go v0.0.0-20200312160651-00c254a52b19/go.mod h1:rGlqNE4CvxZIeiHp0mgrw+/jdGSjJzkZ0n78hhHMdfM=
-github.com/TykTechnologies/storage v1.0.1 h1:YI85mHMofwIrF0QgrRYqKKd2xuPO/lxGe+SR4w2kKkg=
-github.com/TykTechnologies/storage v1.0.1/go.mod h1:+0S3KuNlLGBTMTSFREuZFm315zzXjuuCO4QSAPy+d3M=
+github.com/TykTechnologies/storage v1.0.2 h1:bWaLbpDmsjxT/8QVl9Fpuz1w1orqa/COvs1Gih+fvYE=
+github.com/TykTechnologies/storage v1.0.2/go.mod h1:+0S3KuNlLGBTMTSFREuZFm315zzXjuuCO4QSAPy+d3M=
 github.com/TykTechnologies/tyk v1.9.2-0.20211217130848-b04d51712be7 h1:zZCE0CA/t+K+k5vAkQL1bGaBKNQi4tEupLNGRpQ8J6U=
 github.com/TykTechnologies/tyk v1.9.2-0.20211217130848-b04d51712be7/go.mod h1:ZWxqJegdwYTy9ez9ReXgFlcCMTs/QovvEDOR5v2Ncpc=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=


### PR DESCRIPTION
upgraded TIB to use storage v1.0.2 (#276)