### PR TITLE
Merging to release-1.4: [TT-8265] Replace satori/go.uuid lib with gofrs/uuid (#247)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,16 +8,28 @@ require (
 	github.com/TykTechnologies/tyk v1.9.2-0.20230530103800-06c018df3563
 	github.com/crewjam/saml v0.4.12
 	github.com/go-ldap/ldap/v3 v3.2.3
+<<<<<<< HEAD
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.1
+=======
+	github.com/go-redis/redis/v8 v8.3.1
+	github.com/gofrs/uuid v3.3.0+incompatible
+	github.com/gorilla/mux v1.7.4
+	github.com/gorilla/sessions v1.2.0
+>>>>>>> 7e6d116... [TT-8265] Replace satori/go.uuid lib with gofrs/uuid (#247)
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/markbates/goth v1.64.2
 	github.com/matryer/is v1.4.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+<<<<<<< HEAD
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.1
+=======
+	github.com/sirupsen/logrus v1.4.3-0.20191026113918-67a7fdcf741f
+	github.com/stretchr/testify v1.7.0
+>>>>>>> 7e6d116... [TT-8265] Replace satori/go.uuid lib with gofrs/uuid (#247)
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -286,9 +286,12 @@ github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6Wezm
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/gobwas/ws v1.0.4/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/gocraft/health v0.0.0-20170925182251-8675af27fef0/go.mod h1:rWibcVfwbUxi/QXW84U7vNTcIcZFd6miwbt8ritxh/Y=
+<<<<<<< HEAD
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+=======
+>>>>>>> 7e6d116... [TT-8265] Replace satori/go.uuid lib with gofrs/uuid (#247)
 github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=


### PR DESCRIPTION
[TT-8265] Replace satori/go.uuid lib with gofrs/uuid (#247)

* [TT-8265] Replace satori/go.uuid lib with gofrs/uuid

* Use v4 UUID

* gofmt, uuid import/function name fix

---------

Co-authored-by: Tit Petric <tit@tyk.io>

[TT-8265]: https://tyktech.atlassian.net/browse/TT-8265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-8265]: https://tyktech.atlassian.net/browse/TT-8265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ