### PR TITLE
TT-11298 added possibilit to fill the state by url or form encoded body

### DIFF
--- a/tothic/tothic.go
+++ b/tothic/tothic.go
@@ -130,11 +130,25 @@ func BeginAuthHandler(res http.ResponseWriter, req *http.Request, toth *toth.Tot
 	http.Redirect(res, req, url, http.StatusTemporaryRedirect)
 }
 
-// GetState gets the state string associated with the given request
-// This state is sent to the provider and can be retrieved during the
-// callback.
+// GetState gets the state returned by the provider during the callback.
+// This is used to prevent CSRF attacks, see
+// http://tools.ietf.org/html/rfc6749#section-10.12
 var GetState = func(req *http.Request) string {
-	return "state"
+	params := req.URL.Query()
+
+	var state string
+
+	if params.Encode() == "" && req.Method == http.MethodPost {
+		state = req.FormValue("state")
+	} else {
+		state = params.Get("state")
+	}
+
+	if state == "" {
+		state = "state"
+	}
+
+	return state
 }
 
 /*

--- a/tothic/tothic_test.go
+++ b/tothic/tothic_test.go
@@ -1,8 +1,11 @@
 package tothic
 
 import (
+	"net/http"
+	"net/url"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -32,4 +35,33 @@ func assert(t *testing.T, expected interface{}, actual interface{}) {
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected %v, actual %v", expected, actual)
 	}
+}
+
+func TestGetState(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	assert(t, "state", GetState(req))
+
+	req, _ = http.NewRequest(http.MethodGet, "http://localhost?state=FooBar", nil)
+	assert(t, "FooBar", GetState(req))
+
+	req, _ = http.NewRequest(http.MethodPost, "http://localhost", nil)
+	assert(t, "state", GetState(req))
+
+	req, _ = http.NewRequest(http.MethodPost, "http://localhost?state=FooBar", nil)
+	assert(t, "FooBar", GetState(req))
+
+	data := url.Values{}
+	data.Add("state", "BarBaz")
+
+	requestBody := data.Encode()
+
+	req, _ = http.NewRequest(http.MethodPost, "http://localhost", strings.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	assert(t, "BarBaz", GetState(req))
+
+	req, _ = http.NewRequest(http.MethodPost, "http://localhost?state=FooBar", strings.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	assert(t, "FooBar", GetState(req))
 }


### PR DESCRIPTION
## Description
In the current implementation of tib the state used is always the value `state` this is contradicting the RFC 6749

## Related Issue
https://github.com/TykTechnologies/tyk-identity-broker/issues/388
Tyk Support Request #18436
Tyk Feature Issue: TT-11298

## Motivation and Context
It enables the application that wants to log in via tib to send its own state what makes it opaque and non guessable. 
But in the implementation I kept the hardcoded `state` as a fallback to keep it backwards compatible.

## How This Has Been Tested
I tested this in our tyk on prem production environment with a oauth provider that required a minimum length of the state value. Also I added tests to the tothic_test.go file.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
- [x ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
