### PR TITLE
TT-12174 Added support for proxy settings loaded from environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func init() {
 	// We set the http client's Transport to do InsecureSkipVerify to avoid error in case the certificate
 	// was signed by unknown authority, trusting the user to set up his profile with the correct .well-know URL.
 	http.DefaultClient.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: config.SSLInsecureSkipVerify,
 		},


### PR DESCRIPTION
Added `http.ProxyFromEnvironment` to creation of transport for the default client.

## Description
In the main.go file the `transport` of the `http.DefaultClient` is overwritten because `InsecureSkipVerify: config.SSLInsecureSkipVerify` is added. This disables the default behavior of go that the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are used for HTTP connections.

## Related Issue
https://github.com/TykTechnologies/tyk-identity-broker/issues/393

## Motivation and Context
The change allows to use the tyk identity broker to be used in environments where access to external services is managed by a http porxy.

## How This Has Been Tested
Patched image used to gain access to a identiy provider via HTTP Proxy

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
