### PR TITLE
fix: correct dep-guard pattern

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,6 +6,7 @@ on:
       - master
       - release-**
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
     branches:
       - master
       - release-**
@@ -16,7 +17,13 @@ permissions:
   contents: read
 
 jobs:
+  dep-guard:
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@d3fa20888fa2878e877e22bb7702141217290e7c  # main
+    permissions:
+      contents: read
+
   golangci-lint:
+    needs: [dep-guard]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Tyk Identity Broker
@@ -40,6 +47,7 @@ jobs:
             golanglint.xml
 
   ci-test:
+    needs: [dep-guard]
     name: "${{ matrix.databases }}"
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
   schedule:
     - cron: "0 0 * * 1"
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
   push:
     branches:
       - master
@@ -30,7 +31,13 @@ env:
   # startsWith covers pull_request_target too
   BASE_REF: ${{startsWith(github.event_name, 'pull_request') && github.base_ref || github.ref_name}}
 jobs:
+  dep-guard:
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@d3fa20888fa2878e877e22bb7702141217290e7c  # main
+    permissions:
+      contents: read
+
   goreleaser:
+    needs: [dep-guard]
     if: github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ubuntu-latest-m


### PR DESCRIPTION
## Summary

- Add `dep-guard` job using the org-standard reusable workflow (no bogus `if:` condition -- the reusable workflow handles label checking internally)
- Add `permissions: contents: read` to the dep-guard job
- Downstream jobs use plain `needs: [dep-guard]` without `always()/skipped` fallback that would defeat the guard
- Add `labeled` to `pull_request` trigger types so the guard can react to label changes

Matches the pattern used in `tyk`, `tyk-analytics`, and other org repos.

Supersedes the dep-guard portion of #451 which used the wrong pattern (`dependency-guard` name, bogus `if:` on the guard job, `always() && skipped` on downstream jobs).

## Test plan

- [ ] Open a PR without the `approved` label -- CI jobs should be blocked by dep-guard
- [ ] Add the `approved` label -- CI jobs should proceed
- [ ] Push events and scheduled runs should skip dep-guard (reusable workflow handles this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)