### PR TITLE
[TT-16977] fix: update actions/download-artifact from v3 to v4

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -102,11 +102,11 @@ jobs:
         with:
           go-version: 1.22.6
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
       - name: Download golangcilint artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: golangcilint
       - name: Check reports existence


### PR DESCRIPTION
## Summary
- Update `actions/download-artifact` from v3 to v4 in `.github/workflows/ci-tests.yml` (2 occurrences in the `sonar-cloud-analysis` job)
- GitHub has fully deprecated v3 of upload-artifact and download-artifact; workflows using v3 are now rejected
- All upload-artifact references were already at v4; only download-artifact needed updating

## Test plan
- [ ] Verify the CI tests workflow (`ci-tests.yml`) runs successfully, in particular the `sonar-cloud-analysis` job which downloads coverage and golangcilint artifacts

Generated with [Claude Code](https://claude.com/claude-code)