### PR TITLE
[TT-16950] fix: make Docker images backward compatible with runAsUser: 1000

### DIFF
--- a/ci/Dockerfile.distroless
+++ b/ci/Dockerfile.distroless
@@ -10,11 +10,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # The _ after the pkg name is to match tyk-gateway strictly and not tyk-gateway-fips (for example)
 COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
-RUN dpkg -i /${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb && rm /*.deb
+ARG NONROOT_CHOWN=false
+RUN dpkg -i /${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb && rm /*.deb \
+    && chmod -R a+rX /opt/tyk-identity-broker/ \
+    && if [ "$NONROOT_CHOWN" = "true" ]; then chown -R 65532:65532 /opt/tyk-identity-broker/; fi
 
 FROM ${BASE_IMAGE}
 
-COPY --chown=65532:65532 --from=deb /opt/tyk-identity-broker /opt/tyk-identity-broker
+COPY --from=deb /opt/tyk-identity-broker /opt/tyk-identity-broker
 
 ARG PORTS
 EXPOSE $PORTS


### PR DESCRIPTION
## Summary
Remove --chown=65532:65532 from non-FIPS Dockerfile builds to restore
backward compatibility with helm charts using runAsUser: 1000.

## Test plan
- [ ] Service starts with runAsUser: 1000
- [ ] Service starts with runAsUser: 65532

🤖 Generated with [Claude Code](https://claude.com/claude-code)