### PR TITLE
[TT-17030] Migrate release workflow from PAT to GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,13 @@ jobs:
       std_tags: ${{ steps.ci_metadata_std.outputs.tags }}
       commit_author: ${{ steps.set_outputs.outputs.commit_author}}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
       - name: Checkout of tyk-identity-broker
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -117,7 +124,7 @@ jobs:
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          git config --global url."https://${{ secrets.ORG_GH_TOKEN }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk-identity-broker
           goreleaser release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign,docker' || '--skip=docker' }}' | tee /tmp/build.sh
           chmod +x /tmp/build.sh


### PR DESCRIPTION
## Summary

- Replace `secrets.ORG_GH_TOKEN` (PAT) with GitHub App token (`actions/create-github-app-token`) in the release workflow
- Add `app-token` step to the `goreleaser` job
- Token is used in `git config` inside the Docker build script for private Go module access

> **Note:** The `sbom` reusable workflow call still passes `secrets.ORG_GH_TOKEN` because reusable workflow jobs (`uses:`) cannot have steps injected. This will be addressed when the `sbom.yaml` workflow in `github-actions` is updated to accept the token as an input.

> **Note:** This workflow is generated by gromit. The gromit templates should be updated to reflect this change for future regenerations.

## Test plan

- [ ] Verify the release workflow runs successfully on a PR
- [ ] Confirm goreleaser build completes (private Go modules resolve via app token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)