### PR TITLE
[TT-17030] Update reusable workflow secrets to use GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,4 +380,5 @@ jobs:
     secrets:
       DEPDASH_URL: ${{ secrets.DEPDASH_URL }}
       DEPDASH_KEY: ${{ secrets.DEPDASH_KEY }}
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Update sbom caller in `release.yml` to pass `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` instead of `ORG_GH_TOKEN`

## Test plan
- [ ] Verify sbom workflow still runs on releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)