### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk-identity-broker
           goreleaser release --clean -f ${{ matrix.goreleaser }} ${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign,docker' || '--skip=docker' }}' | tee /tmp/build.sh
           chmod +x /tmp/build.sh


### PR DESCRIPTION
## Summary
- Replace `url."https://${TOKEN}@github.com".insteadOf` with `url."https://x-access-token:${TOKEN}@github.com/".insteadOf` in release.yml (1 occurrence)
- The bare token format doesn't work when `actions/checkout` has configured a credential helper; the `x-access-token:` prefix and trailing slashes fix this

## Test plan
- [ ] Verify release workflow can pull private Go modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)