### PR TITLE
[TT-17339 master] Implement Floating tags in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,13 +172,27 @@ jobs:
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          push: true
+          outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.ci_metadata_std.outputs.tags }}
           labels: ${{ steps.ci_metadata_std.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-identity-broker
+      - name: Verify compression format for std CI image
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        run: |
+          # Resolve the first tag for verification
+          TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
+          echo "Inspecting layer compression for tag: $TAG"
+
+          docker buildx imagetools inspect --raw "$TAG" > manifest.json
+          if grep -q "tar+zstd" manifest.json; then
+            echo "::error::Image contains zstd-compressed layers! This is incompatible with legacy registries."
+            cat manifest.json | grep mediaType
+            exit 1
+          fi
+          echo "Success: All layers are uniformly compressed using gzip."
       - name: Docker metadata for std tag push
         id: tag_metadata_std
         if: startsWith(github.ref, 'refs/tags')
@@ -207,11 +221,25 @@ jobs:
           file: ci/Dockerfile.distroless
           provenance: mode=max
           cache-from: type=gha
-          push: true
+          outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
           tags: ${{ steps.tag_metadata_std.outputs.tags }}
           labels: ${{ steps.tag_metadata_std.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-identity-broker
+      - name: Verify compression format for std prod image
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        run: |
+          # Resolve the first tag for verification
+          TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
+          echo "Inspecting layer compression for tag: $TAG"
+
+          docker buildx imagetools inspect --raw "$TAG" > manifest.json
+          if grep -q "tar+zstd" manifest.json; then
+            echo "::error::Image contains zstd-compressed layers! This is incompatible with legacy registries."
+            cat manifest.json | grep mediaType
+            exit 1
+          fi
+          echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ matrix.golang_cross == '1.25-bookworm' }}


### PR DESCRIPTION
Maintain a mutable tag (e.g. production) in the GitHub Actions repo, moved to the latest commit. Product repos reference @production and pick up updates automatically.
This is a follow up of the Spike ticket: https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/451?assignee=5ed4afcb53ec400c2c067d80&selectedIssue=TT-17303 
