### PR TITLE
TT-16953: remove side effects from Get() func and move setting log level logic to init

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -24,9 +24,7 @@ func init() {
 
 	log.Formatter = formatter
 	rawLog.Formatter = new(RawFormatter)
-}
 
-func Get() *logrus.Logger {
 	switch strings.ToLower(os.Getenv("TYK_LOGLEVEL")) {
 	case "error":
 		log.SetLevel(logrus.ErrorLevel)
@@ -37,6 +35,9 @@ func Get() *logrus.Logger {
 	default:
 		log.SetLevel(logrus.InfoLevel)
 	}
+}
+
+func Get() *logrus.Logger {
 	return log
 }
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -13,10 +13,7 @@ import (
 // which would silently reset any level configured by the caller.
 func TestGetIsPureGetter(t *testing.T) {
 	Get().SetLevel(logrus.ErrorLevel)
-
-	for range 10 {
-		Get()
-	}
+	Get()
 
 	assert.Equal(t, logrus.ErrorLevel, Get().Level)
 }
@@ -36,9 +33,7 @@ func TestSetLoggerLevelNotOverwritten(t *testing.T) {
 
 	SetLogger(injected)
 
-	for range 10 {
-		Get()
-	}
+	Get()
 
 	assert.Equal(t, logrus.ErrorLevel, Get().Level)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,44 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetIsPureGetter verifies that calling Get() multiple times never mutates
+// the logger's level. This is a regression test for the previous behaviour
+// where Get() read TYK_LOGLEVEL and called SetLevel on every invocation,
+// which would silently reset any level configured by the caller.
+func TestGetIsPureGetter(t *testing.T) {
+	Get().SetLevel(logrus.ErrorLevel)
+
+	for range 10 {
+		Get()
+	}
+
+	assert.Equal(t, logrus.ErrorLevel, Get().Level)
+}
+
+// TestSetLoggerLevelNotOverwritten verifies that after an embedder injects its
+// own logger via SetLogger, subsequent Get() calls do not overwrite that
+// logger's level. This covers the dashboard embedding scenario where
+// TYK_DB_LOGLEVEL=error was being ignored because TIB's Get() reset the
+// shared logger back to InfoLevel.
+func TestSetLoggerLevelNotOverwritten(t *testing.T) {
+	t.Cleanup(func() {
+		SetLogger(logrus.New())
+	})
+
+	injected := logrus.New()
+	injected.SetLevel(logrus.ErrorLevel)
+
+	SetLogger(injected)
+
+	for range 10 {
+		Get()
+	}
+
+	assert.Equal(t, logrus.ErrorLevel, Get().Level)
+}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

## Description
When the dashboard embeds TIB and calls initializer.CreateBackendFromRedisConn(), the backends internally call log.Get() to pick up the injected logger. Get() had a side effect: it read TYK_LOGLEVEL and called SetLevel on every invocation. This meant that if SetLogger() had already been called (replacing TIB's logger with the dashboard's shared logger), Get()'s SetLevel call would silently reset the dashboard's log level — overwriting whatever the dashboard had configured, including via TYK_DB_LOGLEVEL which TIB has no knowledge of.

This change moves the level configuration into init(), where it runs once at package startup. Get() becomes a pure getter with no side effects. The dashboard no longer needs to re-apply its log level after initializing TIB.

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
  - [ ] If new config option added, ensure that it can be set via ENV variable
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`



<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16953" title="TT-16953" target="_blank">TT-16953</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | [Innersource] Implement Dashboard specific application log verbosity control |

Generated at: 2026-06-05 12:20:26

</details>

<!---TykTechnologies/jira-linter ends here-->


