### PR TITLE
[TT-17901] Resolve the organisation from an identity provider claim

### DIFF
--- a/tap/identity-handlers/tyk_handler.go
+++ b/tap/identity-handlers/tyk_handler.go
@@ -160,6 +160,7 @@ func (t *TykIdentityHandler) CreateIdentity(i interface{}) (string, error) {
 	displayName := ""
 	var groupsIDs []string
 	var groupID string
+	orgID := t.profile.OrgID
 	if ok {
 		email = GetEmail(gUser, t.profile.CustomEmailField)
 
@@ -180,11 +181,13 @@ func (t *TykIdentityHandler) CreateIdentity(i interface{}) (string, error) {
 		if len(groupsIDs) > 0 {
 			groupID = groupsIDs[0]
 		}
+
+		orgID = GetOrgId(gUser, t.profile.CustomUserOrgField, t.profile.DefaultOrgID, t.profile.OrgMapping, t.profile.OrgID)
 	}
 	tykHandlerLogger.Debugf("The GroupIDs %s used for SSO: ", groupsIDs)
 	accessRequest := SSOAccessData{
 		ForSection:                thisModule,
-		OrgID:                     t.profile.OrgID,
+		OrgID:                     orgID,
 		EmailAddress:              email,
 		DisplayName:               displayName,
 		GroupsIDs:                 groupsIDs,
@@ -578,4 +581,75 @@ func GetGroupId(gUser goth.User, CustomUserGroupField, DefaultUserGroup string, 
 	}
 
 	return groupsIDs
+}
+
+// Helper function to return either the DefaultOrgID or the org the profile itself is bound to.
+// We can never hand the dashboard an empty org, that would mint a session without a tenant.
+func defaultOrProfileOrgID(DefaultOrgID, profileOrgID string) string {
+	if DefaultOrgID == "" {
+		return profileOrgID
+	}
+	return DefaultOrgID
+}
+
+// orgClaimStringer turns the raw org claim into the list of values to look up in the mapping.
+// Unlike groups, the org claim is single valued so a plain string is taken as-is (an org name
+// may contain spaces), lists are handed over to groupsStringer as the IDPs send them. Anything
+// else is not something we know how to read, so it resolves to nothing and we fall back.
+func orgClaimStringer(rawOrgs interface{}) []string {
+	switch v := rawOrgs.(type) {
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	case []string:
+		return groupsStringer(rawOrgs, "")
+	case []interface{}:
+		// groupsStringer asserts the members are strings, check before it does so a
+		// numeric tenant id in the claim cannot take the login down
+		for _, item := range v {
+			if _, ok := item.(string); !ok {
+				return nil
+			}
+		}
+		return groupsStringer(rawOrgs, "")
+	default:
+		return nil
+	}
+}
+
+// GetOrgId returns the org the user is logging into. If the profile has no CustomUserOrgField then
+// this is the org the profile itself belongs to, which is the behaviour of a single tenant profile.
+// Otherwise the claim is mapped through OrgMapping, falling back to DefaultOrgID and then to the
+// profile's own org, so the returned org id is never empty.
+func GetOrgId(gUser goth.User, CustomUserOrgField, DefaultOrgID string, orgMapping map[string]string, profileOrgID string) string {
+	if CustomUserOrgField == "" {
+		return profileOrgID
+	}
+
+	rawOrgs, exists := gUser.RawData[CustomUserOrgField]
+	if !exists || rawOrgs == nil {
+		orgID := defaultOrProfileOrgID(DefaultOrgID, profileOrgID)
+		tykHandlerLogger.WithField("org_claim_field", CustomUserOrgField).WithField("org_id", orgID).
+			Warning("Org claim not found in the identity, falling back")
+		return orgID
+	}
+
+	orgs := orgClaimStringer(rawOrgs)
+
+	// a user belongs to one tenant only, so the first value we can map wins, anything
+	// else would make the tenant ambiguous
+	for _, org := range orgs {
+		if oid, ok := orgMapping[org]; ok && oid != "" {
+			tykHandlerLogger.WithField("org_claim_field", CustomUserOrgField).WithField("org_claim", org).
+				WithField("org_id", oid).Debug("Resolved org from the identity claim")
+			return oid
+		}
+	}
+
+	orgID := defaultOrProfileOrgID(DefaultOrgID, profileOrgID)
+	tykHandlerLogger.WithField("org_claim_field", CustomUserOrgField).WithField("org_claim", rawOrgs).
+		WithField("org_id", orgID).Warning("Org claim not mapped to any org, falling back")
+	return orgID
 }

--- a/tap/identity-handlers/tyk_handler_test.go
+++ b/tap/identity-handlers/tyk_handler_test.go
@@ -1,10 +1,15 @@
 package identityHandlers
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/TykTechnologies/tyk-identity-broker/tap"
+	tyk "github.com/TykTechnologies/tyk-identity-broker/tyk-api"
 	"github.com/markbates/goth"
 )
 
@@ -12,12 +17,20 @@ const (
 	TestEmail      = "test@tyk.io"
 	TestId         = "user-id"
 	DefaultGroupId = "default-group-id"
+	ProfileOrgId   = "profile-org-id"
+	DefaultOrgId   = "default-org-id"
 )
 
 var UserGroupMapping = map[string]string{
 	"devs":   "devs-group",
 	"admins": "admins-group",
 	"CN=tyk_admin,OU=Security Groups,OU=GenericOrg,DC=GenericOrg,DC=COM,DC=GEN": "tyk-admin",
+}
+
+var OrgMapping = map[string]string{
+	"acme":              "acme-org-id",
+	"Globex Industries": "globex-org-id",
+	"CN=tyk_tenant,OU=Security Groups,OU=GenericOrg,DC=GenericOrg,DC=COM,DC=GEN": "tyk-tenant-org-id",
 }
 
 func TestGetEmail(t *testing.T) {
@@ -266,6 +279,362 @@ func Test_defaultOrEmptyGroupIDs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := defaultOrEmptyGroupIDs(tt.defaultUserGroup)
 			assert.Equal(t, tt.expectedGroupIDs, result, "The group IDs should match")
+		})
+	}
+}
+
+func TestGetOrgId(t *testing.T) {
+	cases := []struct {
+		TestName           string
+		CustomUserOrgField string
+		user               goth.User
+		DefaultOrgID       string
+		OrgMapping         map[string]string
+		ProfileOrgID       string
+		ExpectedOrgID      string
+	}{
+		{
+			TestName:           "Custom org field empty, profile org is used",
+			CustomUserOrgField: "",
+			user:               goth.User{},
+			DefaultOrgID:       "",
+			OrgMapping:         OrgMapping,
+			ProfileOrgID:       ProfileOrgId,
+			ExpectedOrgID:      ProfileOrgId,
+		},
+		{
+			TestName:           "Custom org field empty, profile org wins over the default org",
+			CustomUserOrgField: "",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "acme",
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: ProfileOrgId,
+		},
+		{
+			TestName:           "Custom org field set & claim mapped. With default org not set",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "acme",
+				},
+			},
+			DefaultOrgID:  "",
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: "acme-org-id",
+		},
+		{
+			TestName:           "Custom org field set & claim mapped. With default org set",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "acme",
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: "acme-org-id",
+		},
+		{
+			TestName:           "Claim value containing blank spaces is not split",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "Globex Industries",
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: "globex-org-id",
+		},
+		{
+			TestName:           "Claim present but unmapped & default org set",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "unknown-tenant",
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: DefaultOrgId,
+		},
+		{
+			TestName:           "Claim present but unmapped & default org not set",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "unknown-tenant",
+				},
+			},
+			DefaultOrgID:  "",
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: ProfileOrgId,
+		},
+		{
+			TestName:           "Claim absent & default org set",
+			CustomUserOrgField: "my-custom-org-field",
+			user:               goth.User{},
+			DefaultOrgID:       DefaultOrgId,
+			OrgMapping:         OrgMapping,
+			ProfileOrgID:       ProfileOrgId,
+			ExpectedOrgID:      DefaultOrgId,
+		},
+		{
+			TestName:           "Claim absent & default org not set",
+			CustomUserOrgField: "my-custom-org-field",
+			user:               goth.User{},
+			DefaultOrgID:       "",
+			OrgMapping:         OrgMapping,
+			ProfileOrgID:       ProfileOrgId,
+			ExpectedOrgID:      ProfileOrgId,
+		},
+		{
+			TestName:           "Claim present but nil",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": nil,
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: DefaultOrgId,
+		},
+		{
+			TestName:           "Claim is an empty string",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "",
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: DefaultOrgId,
+		},
+		{
+			TestName:           "Claim is an array, the first value that maps wins",
+			CustomUserOrgField: "orgs",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"orgs": []interface{}{
+						"unknown-tenant",
+						"Globex Industries",
+						"acme",
+					},
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: "globex-org-id",
+		},
+		{
+			TestName:           "Claim is an array of strings",
+			CustomUserOrgField: "memberOf",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"memberOf": []string{
+						"CN=Generic Contract Employees,OU=Email_Group,OU=GenericOrg,DC=GenericOrg,DC=COM,DC=GEN",
+						"CN=tyk_tenant,OU=Security Groups,OU=GenericOrg,DC=GenericOrg,DC=COM,DC=GEN",
+					},
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: "tyk-tenant-org-id",
+		},
+		{
+			TestName:           "Claim is an array with no value mapped",
+			CustomUserOrgField: "orgs",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"orgs": []interface{}{"unknown-tenant", "another-unknown-tenant"},
+				},
+			},
+			DefaultOrgID:  "",
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: ProfileOrgId,
+		},
+		{
+			TestName:           "Claim is of a type we cannot read",
+			CustomUserOrgField: "orgs",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"orgs": []interface{}{float64(42)},
+				},
+			},
+			DefaultOrgID:  DefaultOrgId,
+			OrgMapping:    OrgMapping,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: DefaultOrgId,
+		},
+		{
+			TestName:           "Claim maps to an empty org id, it is never returned",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "acme",
+				},
+			},
+			DefaultOrgID:  "",
+			OrgMapping:    map[string]string{"acme": ""},
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: ProfileOrgId,
+		},
+		{
+			TestName:           "Mapping not set at all",
+			CustomUserOrgField: "my-custom-org-field",
+			user: goth.User{
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "acme",
+				},
+			},
+			DefaultOrgID:  "",
+			OrgMapping:    nil,
+			ProfileOrgID:  ProfileOrgId,
+			ExpectedOrgID: ProfileOrgId,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.TestName, func(t *testing.T) {
+			orgID := GetOrgId(tc.user, tc.CustomUserOrgField, tc.DefaultOrgID, tc.OrgMapping, tc.ProfileOrgID)
+			assert.Equal(t, tc.ExpectedOrgID, orgID)
+			assert.NotEmpty(t, orgID, "The org id handed to the dashboard must never be empty")
+		})
+	}
+}
+
+func Test_defaultOrProfileOrgID(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultOrgID  string
+		profileOrgID  string
+		expectedOrgID string
+	}{
+		{
+			name:          "Empty default org",
+			defaultOrgID:  "",
+			profileOrgID:  ProfileOrgId,
+			expectedOrgID: ProfileOrgId,
+		},
+		{
+			name:          "Non-empty default org",
+			defaultOrgID:  DefaultOrgId,
+			profileOrgID:  ProfileOrgId,
+			expectedOrgID: DefaultOrgId,
+		},
+		{
+			name:          "Both empty",
+			defaultOrgID:  "",
+			profileOrgID:  "",
+			expectedOrgID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := defaultOrProfileOrgID(tt.defaultOrgID, tt.profileOrgID)
+			assert.Equal(t, tt.expectedOrgID, result, "The org id should match")
+		})
+	}
+}
+
+// TestCreateIdentityOrgID checks the org resolution reaches the SSOAccessData we post to the dashboard
+func TestCreateIdentityOrgID(t *testing.T) {
+	cases := []struct {
+		TestName      string
+		profile       tap.Profile
+		user          goth.User
+		ExpectedOrgID string
+	}{
+		{
+			TestName: "Profile without a custom org field keeps posting its own org",
+			profile: tap.Profile{
+				ActionType: tap.GenerateOrLoginUserProfile,
+				OrgID:      ProfileOrgId,
+			},
+			user: goth.User{
+				Email: TestEmail,
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "acme",
+				},
+			},
+			ExpectedOrgID: ProfileOrgId,
+		},
+		{
+			TestName: "Profile with a custom org field posts the mapped org",
+			profile: tap.Profile{
+				ActionType:         tap.GenerateOrLoginUserProfile,
+				OrgID:              ProfileOrgId,
+				CustomUserOrgField: "my-custom-org-field",
+				OrgMapping:         OrgMapping,
+				DefaultOrgID:       DefaultOrgId,
+			},
+			user: goth.User{
+				Email: TestEmail,
+				RawData: map[string]interface{}{
+					"my-custom-org-field": "acme",
+				},
+			},
+			ExpectedOrgID: "acme-org-id",
+		},
+		{
+			TestName: "Profile with a custom org field but no claim posts the default org",
+			profile: tap.Profile{
+				ActionType:         tap.GenerateOrLoginUserProfile,
+				OrgID:              ProfileOrgId,
+				CustomUserOrgField: "my-custom-org-field",
+				OrgMapping:         OrgMapping,
+				DefaultOrgID:       DefaultOrgId,
+			},
+			user: goth.User{
+				Email: TestEmail,
+			},
+			ExpectedOrgID: DefaultOrgId,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.TestName, func(t *testing.T) {
+			var accessRequest SSOAccessData
+			api := &tyk.TykAPI{
+				CustomDispatcher: func(_ tyk.Endpoint, _ string, _ string, body io.Reader) ([]byte, int, error) {
+					sentData, err := io.ReadAll(body)
+					if err != nil {
+						return []byte{}, http.StatusInternalServerError, err
+					}
+
+					if err := json.Unmarshal(sentData, &accessRequest); err != nil {
+						return []byte{}, http.StatusInternalServerError, err
+					}
+
+					return []byte(`{"Meta":"the-nonce"}`), http.StatusOK, nil
+				},
+			}
+
+			handler := TykIdentityHandler{API: api}
+			assert.NoError(t, handler.Init(tc.profile))
+
+			nonce, err := handler.CreateIdentity(tc.user)
+			assert.NoError(t, err)
+			assert.Equal(t, "the-nonce", nonce)
+			assert.Equal(t, tc.ExpectedOrgID, accessRequest.OrgID)
 		})
 	}
 }

--- a/tap/profile.go
+++ b/tap/profile.go
@@ -35,6 +35,9 @@ type Profile struct {
 	CustomUserGroupField      string                 `bson:"CustomUserGroupField" json:"CustomUserGroupField"`
 	UserGroupMapping          map[string]string      `bson:"UserGroupMapping" json:"UserGroupMapping"`
 	UserGroupSeparator        string                 `bson:"UserGroupSeparator" json:"UserGroupSeparator"`
+	CustomUserOrgField        string                 `bson:"CustomUserOrgField" json:"CustomUserOrgField"`
+	OrgMapping                map[string]string      `bson:"OrgMapping" json:"OrgMapping"`
+	DefaultOrgID              string                 `bson:"DefaultOrgID" json:"DefaultOrgID"`
 	SSOOnlyForRegisteredUsers bool                   `bson:"SSOOnlyForRegisteredUsers" json:"SSOOnlyForRegisteredUsers"`
 }
 


### PR DESCRIPTION
## Description

Lets a **single identity broker profile serve several Tyk organisations**, with the tenant chosen by an identity-provider claim.

Today `CompleteIdentityActionForDashboard` stamps the profile's own `OrgID` into every `SSOAccessData` it posts to the Dashboard:

```go
// tap/identity-handlers/tyk_handler.go (before)
OrgID: t.profile.OrgID,
```

That binds one profile to one organisation, so a multi-tenant deployment needs a separate profile — and therefore a separate SSO URL (`/auth/<profile-id>/<provider>`) — per tenant. Customers who can only publish **one** OIDC entry point across all their organisations cannot use it at all.

This adds an org resolver that mirrors the group mapping already in this file, and changes that one line to use it.

### How it resolves

New `Profile` fields, sitting next to the existing group-mapping ones and following the same shape:

| Field | Purpose |
|---|---|
| `CustomUserOrgField` | the claim holding the tenant |
| `OrgMapping map[string]string` | claim value → Tyk organisation id |
| `DefaultOrgID` | fallback when the claim is absent or unmapped |

`GetOrgId()` is a twin of `GetGroupId()`:

- `CustomUserOrgField` empty → **the profile's own `OrgID`** (today's behaviour, returned before anything else is consulted)
- claim missing / nil / unreadable → `DefaultOrgID`, else the profile's `OrgID`
- claim present → first value with a mapping entry; no hit → `DefaultOrgID`, else the profile's `OrgID`

### Two deliberate design decisions worth reviewing

**1. The resolved org is never empty.** An empty organisation would let the Dashboard mint a session with no tenant, so every fallback path terminates at the profile's `OrgID`. A mapping entry whose *value* is blank is treated as a **miss**, not a hit, for the same reason.

**2. A plain string claim is not split on a separator** — unlike `GetGroupId`, which splits on `UserGroupSeparator`. A tenant must be unambiguous, and organisation names routinely contain spaces (`"Globex Industries"` is covered by a test). Consequently there is no `OrgSeparator` field, and a comma-separated multi-tenant string will not be split. List claims are still read — OIDC commonly sends arrays — and `[]interface{}` elements are **type-checked before use**, because `groupsStringer` asserts `str.(string)` and would panic the login on a numeric tenant id. An unreadable claim falls back rather than erroring.

### Backward compatibility

An existing profile has no `CustomUserOrgField`, so `GetOrgId` returns the profile's `OrgID` on the first branch — byte-identical behaviour. This is asserted by a dedicated test, and mutation-verified (see below).

Only the **dashboard** SSO path is multi-org. `CompleteIdentityActionForPortal`, `CompleteIdentityActionForOAuth` and `CompleteIdentityActionForTokenAuth` still use `t.profile.OrgID` and are untouched — worth confirming that portal tenants do not need the same treatment.

## Related Issue

[TT-17901](https://tyktech.atlassian.net/browse/TT-17901)

Parent epic: [TT-17773 — Multi-Organisation SSO](https://tyktech.atlassian.net/browse/TT-17773)

## How This Has Been Tested

```
$ go build ./...
(no output)

$ go test ./tap/... ./providers/... -count=1
?   	github.com/TykTechnologies/tyk-identity-broker/tap	[no test files]
ok  	github.com/TykTechnologies/tyk-identity-broker/tap/identity-handlers	0.364s
?   	github.com/TykTechnologies/tyk-identity-broker/tap/tapProvider	[no test files]
ok  	github.com/TykTechnologies/tyk-identity-broker/providers	4.614s
```

23 new table-driven cases across `TestGetOrgId` (17), `Test_defaultOrProfileOrgID` (3) and `TestCreateIdentityOrgID` (3). The last drives the real `CreateIdentity` through `tyk.TykAPI.CustomDispatcher`, unmarshals the posted body back into `SSOAccessData` and asserts its `OrgID` — so the wiring is covered, not just the resolver. Every `GetOrgId` case also asserts the result is non-empty.

`gofmt -l tap/` clean.

**Mutation-tested** — each guard was reverted in the source, the suite re-run, and the source restored. All five mutations killed their test:

| Reverted | Test that failed |
|---|---|
| handler never calls `GetOrgId` | `TestCreateIdentityOrgID` (2 subtests) |
| `oid != ""` mapping-hit check dropped | `Claim maps to an empty org id` |
| backward-compat early return weakened to consult `DefaultOrgID` | `Custom org field empty, profile org wins over the default org` |
| string claim split via `groupsStringer` | `Claim value containing blank spaces is not split` |
| `[]interface{}` element type check removed | `Claim is of a type we cannot read` (panics: `interface {} is float64, not string`) |

### Pre-existing `go vet` findings (not introduced here)

```
tap/profile.go:64:23: call of Unmarshal passes non-pointer as second argument
tothic/tothic.go:49:23: call of Unmarshal passes non-pointer as second argument
```

Both reproduce on unmodified `master` (verified by stashing this change and re-running; `tap/profile.go:61` before the 3-line insert shifted it to `:64`). They are in `Profile.UnmarshalBinary` and `tothic.go`, untouched by this PR. Not fixed here — `UnmarshalBinary` has a value receiver, so correcting it is a signature change and out of scope.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Requesting to pull a topic branch, against `master`
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] `go fmt`, `go vet` (two pre-existing findings noted above)
- [ ] **Documentation** — the README documents the group-mapping fields (~L952-962); the equivalent org-mapping section still needs writing before release.

## Notes for the reviewer

- The Dashboard companion PR is **TykTechnologies/tyk-analytics#6049**, which pins this commit until a TIB release is cut. **This should merge and release first.**
- `v1.7.3` is not an ancestor of `master` — it is a release-branch tag whose only extra commits are a copyright-year bump and a version bump. Cutting a release from `master` including this change is therefore functionally a fast-forward, but the version numbering needs a deliberate decision.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TT-17774]: https://tyktech.atlassian.net/browse/TT-17774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[TT-17901]: https://tyktech.atlassian.net/browse/TT-17901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ