### PR TITLE
[TT-17981] Add a testing guide to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,89 @@ POST /Authorization: test-secret
 
 The existing profiles.json file will be backed up to a new file, and a the current profiles data in memory will be flushed to disk as the new profiles.json file. Backups are time stamped (e.g. `profiles_backup_1452677499.json`).
 
+## Running the tests
+
+CI runs the test suite with Go 1.26 (`GO_VERSION` in
+[`.github/workflows/ci-tests.yml`](.github/workflows/ci-tests.yml)) across three storage
+back ends: `file`, `mongo-mgo` and `mongo-official`. You can run the same suite locally.
+
+### Prerequisites
+
+Install `goimports`, which the test script uses for its import-ordering check:
+
+```
+go install golang.org/x/tools/cmd/goimports@v0.33.0
+```
+
+Make sure the install directory is on your `PATH`, otherwise the script fails at the
+`goimports` step:
+
+```
+export PATH="$PATH:$(go env GOPATH)/bin"
+```
+
+### Start Redis and MongoDB
+
+The `mongo-mgo` and `mongo-official` variants need Redis and MongoDB reachable on their
+**default ports**, because the test suite connects to `localhost:6379` and
+`mongodb://localhost/tyk_identity_broker`. The `file` variant needs neither.
+
+[`docker-compose.test.yml`](docker-compose.test.yml) in the repository root defines both
+services with the image versions CI uses. Start them and wait for both to report healthy:
+
+```
+docker compose -f docker-compose.test.yml up -d --wait
+```
+
+Check ports 6379 and 27017 for collisions before starting, or point the suite at your own
+Redis and MongoDB instances on those ports instead.
+
+### Run the tests
+
+For a quick check, run the packages directly:
+
+```
+go test ./...
+```
+
+To run what CI runs, including `go vet`, the `gofmt` and `goimports` checks, and
+per-package coverage with the race detector enabled, use the CI script. With no argument
+it uses the `file` back end:
+
+```
+./bin/ci-tests.sh
+```
+
+The Mongo variants take the back end as an argument:
+
+```
+./bin/ci-tests.sh mongo-mgo
+./bin/ci-tests.sh mongo-official
+```
+
+Two tests in `data_loader` are skipped under the `file` back end and only run under the
+Mongo variants, so run all three to cover the suite.
+
+### Clean up
+
+```
+docker compose -f docker-compose.test.yml down
+```
+
+`./bin/ci-tests.sh` writes a `<package>-<backend>.cov` coverage file per package into the
+repository root. These are build artifacts. Remove them before committing:
+
+```
+rm -f *.cov
+```
+
+### Troubleshooting
+
+If a Mongo variant stalls and logs `failed to init MongoDB connection ... no reachable
+servers` on a loop, nothing is listening on port 27017. The driver retries instead of
+failing, so the run hangs until the 10 minute per-package test timeout fires. Check that
+the containers are up and that MongoDB is published on 27017 rather than a remapped port.
+
 ## Security Issues
 
 If you discover a security vulnerability within this project, please don't use the issue tracker. Instead, kindly email us directly at [support@tyk.io](mailto:support@tyk.io). We take security seriously and will promptly address your concerns.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,33 @@
+# Redis and MongoDB for running the test suite locally. See "Running the tests"
+# in README.md.
+#
+# Image versions match the CI matrix in .github/workflows/ci-tests.yml.
+#
+# Both services are published on their default ports because the suite connects
+# to fixed addresses: localhost:6379 in backends/iam_auth_test.go and
+# mongodb://localhost/tyk_identity_broker in bin/ci-tests.sh. Remapping either
+# host port means the tests never reach these containers.
+services:
+  redis:
+    image: redis:5
+    container_name: tib-redis-test
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+  mongodb:
+    image: mongo:4.2
+    container_name: tib-mongo-test
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_DATABASE: tyk_identity_broker
+    healthcheck:
+      # mongo:4.2 predates mongosh, so this calls the legacy mongo shell.
+      test: ["CMD", "mongo", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 20


### PR DESCRIPTION
## Description

Adds a `## Running the tests` section to the README, between the Broker API reference and Security Issues, plus a checked-in `docker-compose.test.yml` for the services the suite needs.

The README documents:

- Installing `goimports@v0.33.0` and putting `$(go env GOPATH)/bin` on `PATH`, which `bin/ci-tests.sh` needs for its import check.
- Starting the services with `docker compose -f docker-compose.test.yml up -d --wait`.
- `go test ./...` for a quick check, and `./bin/ci-tests.sh [file|mongo-mgo|mongo-official]` for what CI runs.
- Removing the `*.cov` files the script leaves in the repository root.
- The symptom to look for when MongoDB is unreachable.

Two details in `docker-compose.test.yml` are deliberate, and commented in the file:

- Redis is published on 6379 and MongoDB on 27017. The suite connects to `localhost:6379` (`backends/iam_auth_test.go:174`) and `mongodb://localhost/tyk_identity_broker` (`bin/ci-tests.sh:27`), so a remapped host port is never reached. With MongoDB on another port the run does not fail — it logs `no reachable servers` on a loop until the 10 minute per-package timeout fires. That symptom is in the Troubleshooting subsection.
- The MongoDB health check calls `mongo`, not `mongosh`. `mongo:4.2` predates `mongosh`, so a `mongosh` check never passes and the container never reports healthy, which breaks `up --wait`.

Image versions (`redis:5`, `mongo:4.2`) and the Go version reference (1.26) match the CI matrix in `.github/workflows/ci-tests.yml`.

## Related Issue

None. The README had no testing instructions, so the only reference was `bin/ci-tests.sh` and the CI workflow, even though the PR template asks contributors to confirm that all tests passed.

## Motivation and Context

A new contributor had to read the CI workflow to learn that the suite needs Redis and MongoDB on default ports, that `goimports` is required, and that the script takes a storage back end argument. This writes that down and ships the service definitions alongside it.

Documentation and local tooling only. No application code, dependency, or CI workflow changes.

## How This Has Been Tested

Followed the section as written, with nothing else bound to 6379 or 27017:

- `docker compose -f docker-compose.test.yml up -d --wait` reported both containers healthy in about 11 seconds, confirming the `mongo` health check works where `mongosh` would not.
- `go clean -testcache`, then all three back ends: `file`, `mongo-mgo` and `mongo-official`. Each exited 0 with 10 packages ok and no failures.
- The MongoDB container logged 13 accepted connections, confirming the published ports are the ones the suite actually uses.
- `go vet`, `gofmt -s` and `goimports` checks passed in every run.
- `docker compose ... down` and `rm -f *.cov` left a clean working tree.
- `docker compose -f docker-compose.test.yml config` validates.

## Types of changes

- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **`master` branch** (left side).
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated — not applicable, no dependency changes.
- [ ] When updating library version must provide reason/explanation — not applicable.
- [ ] I have added tests to cover my changes — not applicable, documentation and local tooling only.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `gofmt -s`
  - [x] `go vet`
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17981" title="TT-17981" target="_blank">TT-17981</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | Update README.md / docs about testing our Open Source Core Components |

Generated at: 2026-08-26 12:17:58

</details>

<!---TykTechnologies/jira-linter ends here-->
